### PR TITLE
Add a test to confirm unmarshaling w/o a client-side id works

### DIFF
--- a/jsonapi_test.go
+++ b/jsonapi_test.go
@@ -20,6 +20,7 @@ var (
 
 	// articles
 	articleA        = Article{ID: "1", Title: "A"}
+	articleANoID    = Article{Title: "A"}
 	articleB        = Article{ID: "2", Title: "B"}
 	articlesAB      = []Article{articleA, articleB}
 	articlesABPtr   = []*Article{&articleA, &articleB}
@@ -73,6 +74,7 @@ var (
 	// article bodies
 	emptyBody                         = `{"data":[]}`
 	articleABody                      = `{"data":{"type":"articles","id":"1","attributes":{"title":"A"}}}`
+	articleANoIDBody                  = `{"data":{"type":"articles","attributes":{"title":"A"}}}`
 	articleAInvalidTypeBody           = `{"data":{"type":"not-articles","id":"1","attributes":{"title":"A"}}}`
 	articleOmitTitleFullBody          = `{"data":{"type":"articles","id":"1"}}`
 	articleOmitTitlePartialBody       = `{"data":{"type":"articles","id":"1","attributes":{"subtitle":"A"}}}`

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -30,6 +30,16 @@ func TestUnmarshal(t *testing.T) {
 			expect:      &articleComplete,
 			expectError: nil,
 		}, {
+			description: "*Article (no id)",
+			given:       articleANoIDBody,
+			do: func(body []byte) (any, error) {
+				var a Article
+				err := Unmarshal(body, &a)
+				return &a, err
+			},
+			expect:      &articleANoID,
+			expectError: nil,
+		}, {
 			description: "*Article",
 			given:       articleABody,
 			do: func(body []byte) (any, error) {


### PR DESCRIPTION
Ensures that Unmarshaling a request body w/o an ID works properly. E.g. server-side id's are supported.