### PR TITLE
Fix typo in 3rd party license CSV

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -1,1 +1,1 @@
-Component,Origin,License,Copyrightg
+Component,Origin,License,Copyright


### PR DESCRIPTION
Fix the spelling of "Copyright" in the 3rd party license CSV file