### PR TITLE
Adds MarshalClientMode option

### DIFF
--- a/jsonapi.go
+++ b/jsonapi.go
@@ -8,7 +8,7 @@ import (
 
 // ResourceObject is a JSON:API resource object as defined by https://jsonapi.org/format/1.0/#document-resource-objects
 type resourceObject struct {
-	ID            string               `json:"id"`
+	ID            string               `json:"id,omitempty"`
 	Type          string               `json:"type"`
 	Attributes    map[string]any       `json:"attributes,omitempty"`
 	Relationships map[string]*document `json:"relationships,omitempty"`

--- a/marshal.go
+++ b/marshal.go
@@ -23,6 +23,7 @@ type Marshaler struct {
 	jsonAPImeta    any
 	included       []any
 	link           *Link
+	clientMode     bool
 
 	// fields support sparse fieldsets https://jsonapi.org/format/#fetching-sparse-fieldsets
 	fields map[string][]string
@@ -73,6 +74,13 @@ func MarshalFields(query url.Values) MarshalOption {
 func MarshalLinks(l *Link) MarshalOption {
 	return func(m *Marshaler) {
 		m.link = l
+	}
+}
+
+// MarshalClientMode enables client mode which skips validation only relevant for servers writing JSON:API responses.
+func MarshalClientMode() MarshalOption {
+	return func(m *Marshaler) {
+		m.clientMode = true
 	}
 }
 
@@ -399,7 +407,7 @@ func makeResourceObject(v any, vt reflect.Type, m *Marshaler, isRelationship boo
 	}
 
 	// id (e.g. the primary field) must not be empty
-	if ro.ID == "" {
+	if ro.ID == "" && !m.clientMode {
 		return nil, ErrEmptyPrimaryField
 	}
 

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -573,3 +573,31 @@ func TestMarshalRelationships(t *testing.T) {
 		})
 	}
 }
+
+func TestMarshalClientMode(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		description string
+		given       any
+		expect      string
+	}{
+		{
+			description: "empty primary field",
+			given:       &Article{ID: "", Title: "A"},
+			expect:      articleANoIDBody,
+		},
+	}
+
+	for i, tc := range tests {
+		tc := tc
+		t.Run(fmt.Sprintf("%02d", i), func(t *testing.T) {
+			t.Parallel()
+			t.Log(tc.description)
+
+			actual, err := Marshal(tc.given, MarshalClientMode())
+			is.MustNoError(t, err)
+			is.EqualJSON(t, tc.expect, string(actual))
+		})
+	}
+}


### PR DESCRIPTION
Adds a "client mode" which can optionally be enabled on Marshal. This allows a client (e.g. code making a call to a JSON:API server) to disable verification only relevant to servers marshaling JSON:API responses.

Fixes #6