### PR TITLE
Implement the error interface and move error types to errors.go

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -77,3 +77,31 @@ func (e *PartialLinkageError) Error() string {
 		strings.Join(e.invalidResources, ","),
 	)
 }
+
+// ErrorLink represents a JSON:API error links object as defined by https://jsonapi.org/format/1.0/#error-objects.
+type ErrorLink struct {
+	About string `json:"about,omitempty"`
+}
+
+// ErrorSource represents a JSON:API Error.Source as defined by https://jsonapi.org/format/1.0/#error-objects.
+type ErrorSource struct {
+	Pointer   string `json:"pointer,omitempty"`
+	Parameter string `json:"parameter,omitempty"`
+}
+
+// Error represents a JSON:API error object as defined by https://jsonapi.org/format/1.0/#error-objects.
+type Error struct {
+	ID     string       `json:"id,omitempty"`
+	Links  *ErrorLink   `json:"links,omitempty"`
+	Status string       `json:"status,omitempty"`
+	Code   string       `json:"code,omitempty"`
+	Title  string       `json:"title,omitempty"`
+	Detail string       `json:"detail,omitempty"`
+	Source *ErrorSource `json:"source,omitempty"`
+	Meta   any          `json:"meta,omitempty"`
+}
+
+// Error implements the error interface.
+func (e *Error) Error() string {
+	return fmt.Sprintf("%s: %s", e.Title, e.Detail)
+}

--- a/jsonapi.go
+++ b/jsonapi.go
@@ -22,29 +22,6 @@ type jsonAPI struct {
 	Meta    any    `json:"meta,omitempty"`
 }
 
-// ErrorLink represents a JSON:API error links object as defined by https://jsonapi.org/format/1.0/#error-objects.
-type ErrorLink struct {
-	About string `json:"about,omitempty"`
-}
-
-// ErrorSource represents a JSON:API Error.Source as defined by https://jsonapi.org/format/1.0/#error-objects.
-type ErrorSource struct {
-	Pointer   string `json:"pointer,omitempty"`
-	Parameter string `json:"parameter,omitempty"`
-}
-
-// Error represents a JSON:API error object as defined by https://jsonapi.org/format/1.0/#error-objects.
-type Error struct {
-	ID     string       `json:"id,omitempty"`
-	Links  *ErrorLink   `json:"links,omitempty"`
-	Status string       `json:"status,omitempty"`
-	Code   string       `json:"code,omitempty"`
-	Title  string       `json:"title,omitempty"`
-	Detail string       `json:"detail,omitempty"`
-	Source *ErrorSource `json:"source,omitempty"`
-	Meta   any          `json:"meta,omitempty"`
-}
-
 // LinkObject is a links object as defined by https://jsonapi.org/format/1.0/#document-links
 type LinkObject struct {
 	Href string `json:"href,omitempty"`

--- a/jsonapi_test.go
+++ b/jsonapi_test.go
@@ -100,10 +100,10 @@ var (
 	articleWithIncludeOnlyBody                  = `{"data":{"id":"1","type":"articles","attributes":{"title":"A"}},"included":[{"id":"1","type":"author","attributes":{"name":"A"}}]}`
 
 	// error structs
-	errorsSimpleStruct         = Error{Title: "T"}
-	errorsSimpleSliceSingle    = []Error{errorsSimpleStruct}
+	errorsSimpleStruct         = Error{Title: "T"}           //nolint: errname
+	errorsSimpleSliceSingle    = []Error{errorsSimpleStruct} //nolint: errname
 	errorsSimpleSliceSinglePtr = []*Error{&errorsSimpleStruct}
-	errorsComplexStruct        = Error{
+	errorsComplexStruct        = Error{ //nolint: errname
 		ID:     "1",
 		Links:  &ErrorLink{About: "A"},
 		Status: "S",


### PR DESCRIPTION
Adds the `Error() string` method to satisfy the `error` interface and moved the error type definitions to a more logical file location.