### PR TITLE
Support link objects for error link fields

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -80,7 +80,7 @@ func (e *PartialLinkageError) Error() string {
 
 // ErrorLink represents a JSON:API error links object as defined by https://jsonapi.org/format/1.0/#error-objects.
 type ErrorLink struct {
-	About string `json:"about,omitempty"`
+	About any `json:"about,omitempty"`
 }
 
 // ErrorSource represents a JSON:API Error.Source as defined by https://jsonapi.org/format/1.0/#error-objects.

--- a/jsonapi_test.go
+++ b/jsonapi_test.go
@@ -115,11 +115,24 @@ var (
 	}
 	errorsComplexSliceMany    = []Error{errorsSimpleStruct, errorsComplexStruct}
 	errorsComplexSliceManyPtr = []*Error{&errorsSimpleStruct, &errorsComplexStruct}
+	errorsWithLinkObject      = Error{
+		Links: &ErrorLink{
+			About: &LinkObject{
+				Href: "A",
+				Meta: map[string]any{
+					"key_s": "B",
+					"key_i": 420,
+				},
+			},
+		},
+	}
+	errorsWithInvalidLink = Error{Links: &ErrorLink{About: 1}}
 
 	// error bodies
 	errorsSimpleStructBody     = `{"errors":[{"title":"T"}]}`
 	errorsComplexStructBody    = `{"errors":[{"id":"1","links":{"about":"A"},"status":"S","code":"C","title":"T","detail":"D","source":{"pointer":"PO","parameter":"PA"},"meta":{"K":"V"}}]}`
 	errorsComplexSliceManyBody = `{"errors":[{"title":"T"},{"id":"1","links":{"about":"A"},"status":"S","code":"C","title":"T","detail":"D","source":{"pointer":"PO","parameter":"PA"},"meta":{"K":"V"}}]}`
+	errorsWithLinkObjectBody   = `{"errors":[{"links":{"about":{"href":"A","meta":{"key_i":420,"key_s":"B"}}}}]}`
 )
 
 type Article struct {

--- a/jsonapi_test.go
+++ b/jsonapi_test.go
@@ -115,7 +115,7 @@ var (
 	}
 	errorsComplexSliceMany    = []Error{errorsSimpleStruct, errorsComplexStruct}
 	errorsComplexSliceManyPtr = []*Error{&errorsSimpleStruct, &errorsComplexStruct}
-	errorsWithLinkObject      = Error{
+	errorsWithLinkObject      = Error{ //nolint: errname
 		Links: &ErrorLink{
 			About: &LinkObject{
 				Href: "A",
@@ -126,7 +126,7 @@ var (
 			},
 		},
 	}
-	errorsWithInvalidLink = Error{Links: &ErrorLink{About: 1}}
+	errorsWithInvalidLink = Error{Links: &ErrorLink{About: 1}} //nolint: errname
 
 	// error bodies
 	errorsSimpleStructBody     = `{"errors":[{"title":"T"}]}`

--- a/marshal.go
+++ b/marshal.go
@@ -264,6 +264,17 @@ func makeDocumentErrors(v any, m *Marshaler) (*document, error) {
 		return nil, nil
 	}
 
+	// check for valid error links if present
+	for _, eo := range errorObjects {
+		if eo.Links == nil {
+			continue
+		}
+
+		if _, err := checkLinkValue(eo.Links.About); err != nil {
+			return nil, err
+		}
+	}
+
 	d := newDocument()
 	d.Errors = errorObjects
 

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -221,6 +221,16 @@ func TestMarshal(t *testing.T) {
 			expect:      errorsComplexSliceManyBody,
 			expectError: nil,
 		}, {
+			description: "Error with link object",
+			given:       errorsWithLinkObject,
+			expect:      errorsWithLinkObjectBody,
+			expectError: nil,
+		}, {
+			description: "Error with invalid link",
+			given:       errorsWithInvalidLink,
+			expect:      "",
+			expectError: &TypeError{Actual: "int", Expected: []string{"*LinkObject", "string"}},
+		}, {
 			description: "Error empty",
 			given:       Error{},
 			expect:      `{"errors":[{}]}`,


### PR DESCRIPTION
As per https://jsonapi.org/format/1.0/#error-objects, JSON:API error object links can be any valid JSON:API link representation, including null and link objects, not just strings.