### PR TITLE
Make Error.Status an int for easier integration with http.StatusXXX

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,6 +1,7 @@
 package jsonapi
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
@@ -89,16 +90,38 @@ type ErrorSource struct {
 	Parameter string `json:"parameter,omitempty"`
 }
 
+// Status provides a helper for setting an Error.Status value.
+func Status(s int) *int {
+	return &s
+}
+
 // Error represents a JSON:API error object as defined by https://jsonapi.org/format/1.0/#error-objects.
 type Error struct {
 	ID     string       `json:"id,omitempty"`
 	Links  *ErrorLink   `json:"links,omitempty"`
-	Status string       `json:"status,omitempty"`
+	Status *int         `json:"status,omitempty"`
 	Code   string       `json:"code,omitempty"`
 	Title  string       `json:"title,omitempty"`
 	Detail string       `json:"detail,omitempty"`
 	Source *ErrorSource `json:"source,omitempty"`
 	Meta   any          `json:"meta,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (e *Error) MarshalJSON() ([]byte, error) {
+	var status string
+	if e.Status != nil {
+		status = fmt.Sprintf("%d", *e.Status)
+	}
+
+	type alias Error
+	return json.Marshal(&struct {
+		Status string `json:"status,omitempty"`
+		*alias
+	}{
+		Status: status,
+		alias:  (*alias)(e),
+	})
 }
 
 // Error implements the error interface.

--- a/jsonapi_test.go
+++ b/jsonapi_test.go
@@ -2,6 +2,7 @@ package jsonapi
 
 import (
 	"fmt"
+	"net/http"
 	"strconv"
 	"time"
 )
@@ -106,7 +107,7 @@ var (
 	errorsComplexStruct        = Error{ //nolint: errname
 		ID:     "1",
 		Links:  &ErrorLink{About: "A"},
-		Status: "S",
+		Status: Status(http.StatusInternalServerError),
 		Code:   "C",
 		Title:  "T",
 		Detail: "D",
@@ -130,8 +131,8 @@ var (
 
 	// error bodies
 	errorsSimpleStructBody     = `{"errors":[{"title":"T"}]}`
-	errorsComplexStructBody    = `{"errors":[{"id":"1","links":{"about":"A"},"status":"S","code":"C","title":"T","detail":"D","source":{"pointer":"PO","parameter":"PA"},"meta":{"K":"V"}}]}`
-	errorsComplexSliceManyBody = `{"errors":[{"title":"T"},{"id":"1","links":{"about":"A"},"status":"S","code":"C","title":"T","detail":"D","source":{"pointer":"PO","parameter":"PA"},"meta":{"K":"V"}}]}`
+	errorsComplexStructBody    = `{"errors":[{"id":"1","links":{"about":"A"},"status":"500","code":"C","title":"T","detail":"D","source":{"pointer":"PO","parameter":"PA"},"meta":{"K":"V"}}]}`
+	errorsComplexSliceManyBody = `{"errors":[{"title":"T"},{"id":"1","links":{"about":"A"},"status":"500","code":"C","title":"T","detail":"D","source":{"pointer":"PO","parameter":"PA"},"meta":{"K":"V"}}]}`
 	errorsWithLinkObjectBody   = `{"errors":[{"links":{"about":{"href":"A","meta":{"key_i":420,"key_s":"B"}}}}]}`
 )
 


### PR DESCRIPTION
Go has `http.StatusXXX` values, and generally status are integers. This makes working with `Error.Status` a bit easier while maintaining JSON:API validity.