### PR TITLE
Allow unmarshal to handle empty relationships

### DIFF
--- a/jsonapi.go
+++ b/jsonapi.go
@@ -173,6 +173,11 @@ func (d *document) UnmarshalJSON(data []byte) (err error) {
 	return
 }
 
+// isEmpty returns true if there is no primary data in the given document (i.e. null or []).
+func (d *document) isEmpty() bool {
+	return len(d.DataMany) == 0 && d.DataOne == nil
+}
+
 // verifyFullLinkage returns an error if the given compound document is not fully-linked as
 // described by https://jsonapi.org/format/1.1/#document-compound-documents. That is, there must be
 // a chain of relationships linking all included data to primary data transitively.

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -204,7 +204,7 @@ func (ro *resourceObject) unmarshalFields(v any) error {
 				continue
 			}
 			relDocument, ok := ro.Relationships[name]
-			if !ok {
+			if !ok || (len(relDocument.DataMany) == 0 && relDocument.DataOne == nil) {
 				// relDocument has no relationship data, so there's nothing to do
 				continue
 			}

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -58,7 +58,7 @@ func Unmarshal(data []byte, v any, opts ...UnmarshalOption) (err error) {
 
 func (d *document) unmarshal(v any, m *Unmarshaler) (err error) {
 	// this means we couldn't decode anything (e.g. {}, [], ...)
-	if len(d.DataMany) == 0 && d.DataOne == nil {
+	if d.isEmpty() {
 		err = &RequestBodyError{t: v}
 		return
 	}
@@ -204,7 +204,7 @@ func (ro *resourceObject) unmarshalFields(v any) error {
 				continue
 			}
 			relDocument, ok := ro.Relationships[name]
-			if !ok || (len(relDocument.DataMany) == 0 && relDocument.DataOne == nil) {
+			if !ok || relDocument.isEmpty() {
 				// relDocument has no relationship data, so there's nothing to do
 				continue
 			}

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -209,6 +209,7 @@ func TestUnmarshal(t *testing.T) {
 			expect:      new(Article),
 			expectError: &PartialLinkageError{[]string{"{Type: author, ID: 1}"}},
 		}, {
+			// this test verifies that empty relationship bodies (null and []) unmarshal
 			description: "*ArticleRelated empty relationships",
 			given:       articleRelatedNoOmitEmptyBody,
 			do: func(body []byte) (any, error) {

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -209,6 +209,16 @@ func TestUnmarshal(t *testing.T) {
 			expect:      new(Article),
 			expectError: &PartialLinkageError{[]string{"{Type: author, ID: 1}"}},
 		}, {
+			description: "*ArticleRelated empty relationships",
+			given:       articleRelatedNoOmitEmptyBody,
+			do: func(body []byte) (any, error) {
+				var a ArticleRelated
+				err := Unmarshal(body, &a)
+				return &a, err
+			},
+			expect:      &ArticleRelated{ID: "1", Title: "A"},
+			expectError: nil,
+		}, {
 			description: "*ArticleRelated.Author",
 			given:       articleRelatedAuthorBody,
 			do: func(body []byte) (any, error) {


### PR DESCRIPTION
Closes #17, allowing `null` and `[]` to be valid JSON:API relationship sub-document bodies