### PR TITLE
Validate meta objects in links and errors

### DIFF
--- a/jsonapi_test.go
+++ b/jsonapi_test.go
@@ -45,6 +45,7 @@ var (
 	articleLinkedInvalidRelated                  = ArticleLinkedInvalidRelated{ID: "1"}
 	articleLinkedInvalidMissingFields            = ArticleLinkedInvalidMissingFields{ID: "1"}
 	articleLinkedInvalidMissingFieldsEmptyValues = ArticleLinkedInvalidMissingFieldsEmptyValues{ID: "1"}
+	articleLinkedInvalidSelfMeta                 = ArticleLinkedInvalidSelfMeta{ID: "1"}
 	articleOmitTitleFull                         = ArticleOmitTitle{ID: "1"}
 	articleOmitTitlePartial                      = ArticleOmitTitle{ID: "1", Subtitle: "A"}
 	articleAIntID                                = ArticleIntID{ID: 1, Title: "A"}
@@ -119,7 +120,8 @@ var (
 	}
 	errorsComplexSliceMany    = []Error{errorsSimpleStruct, errorsComplexStruct}
 	errorsComplexSliceManyPtr = []*Error{&errorsSimpleStruct, &errorsComplexStruct}
-	errorsWithLinkObject      = Error{ //nolint: errname
+	errorsWithInvalidMeta     = Error{ID: "1", Meta: "foo"} //nolint: errname
+	errorsWithLinkObject      = Error{                      //nolint: errname
 		Links: &ErrorLink{
 			About: &LinkObject{
 				Href: "A",
@@ -130,7 +132,8 @@ var (
 			},
 		},
 	}
-	errorsWithInvalidLink = Error{Links: &ErrorLink{About: 1}} //nolint: errname
+	errorsWithInvalidLink     = Error{Links: &ErrorLink{About: 1}}                                   //nolint: errname
+	errorsWithInvalidLinkMeta = Error{Links: &ErrorLink{About: &LinkObject{Href: "A", Meta: "foo"}}} //nolint: errname
 
 	// error bodies
 	errorsSimpleStructBody     = `{"errors":[{"title":"T"}]}`
@@ -232,6 +235,14 @@ type ArticleLinkedInvalidMissingFieldsEmptyValues struct {
 func (a *ArticleLinkedInvalidMissingFieldsEmptyValues) Link() *Link {
 	var lo LinkObject
 	return &Link{Self: "", Related: &lo}
+}
+
+type ArticleLinkedInvalidSelfMeta struct {
+	ID string `jsonapi:"primary,articles"`
+}
+
+func (a *ArticleLinkedInvalidSelfMeta) Link() *Link {
+	return &Link{Self: &LinkObject{Href: "foo", Meta: "foo"}}
 }
 
 type ArticleOmitTitle struct {

--- a/marshal.go
+++ b/marshal.go
@@ -264,13 +264,14 @@ func makeDocumentErrors(v any, m *Marshaler) (*document, error) {
 		return nil, nil
 	}
 
-	// check for valid error links if present
+	// check for valid error links and meta fields if present
 	for _, eo := range errorObjects {
-		if eo.Links == nil {
-			continue
+		if eo.Links != nil {
+			if _, err := checkLinkValue(eo.Links.About); err != nil {
+				return nil, err
+			}
 		}
-
-		if _, err := checkLinkValue(eo.Links.About); err != nil {
+		if err := checkMeta(eo.Meta); err != nil {
 			return nil, err
 		}
 	}
@@ -483,17 +484,4 @@ func addOptionalDocumentFields(d *document, m *Marshaler) error {
 	d.Links = m.link
 
 	return nil
-}
-
-func checkMeta(m any) error {
-	if m == nil {
-		return nil
-	}
-
-	mt := derefType(reflect.TypeOf(m))
-	if mt.Kind() == reflect.Struct || mt.Kind() == reflect.Map {
-		return nil
-	}
-
-	return &TypeError{Actual: mt.String(), Expected: []string{"struct", "map"}}
 }

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -132,6 +132,11 @@ func TestMarshal(t *testing.T) {
 			expect:      "",
 			expectError: ErrMissingLinkFields,
 		}, {
+			description: "invalid Link.Self.Meta",
+			given:       &articleLinkedInvalidSelfMeta,
+			expect:      "",
+			expectError: &TypeError{Actual: "string", Expected: []string{"struct", "map"}},
+		}, {
 			description: "string",
 			given:       "a",
 			expect:      "",
@@ -231,6 +236,11 @@ func TestMarshal(t *testing.T) {
 			expect:      errorsComplexSliceManyBody,
 			expectError: nil,
 		}, {
+			description: "Error with invalid meta",
+			given:       errorsWithInvalidMeta,
+			expect:      "",
+			expectError: &TypeError{Actual: "string", Expected: []string{"struct", "map"}},
+		}, {
 			description: "Error with link object",
 			given:       errorsWithLinkObject,
 			expect:      errorsWithLinkObjectBody,
@@ -240,6 +250,11 @@ func TestMarshal(t *testing.T) {
 			given:       errorsWithInvalidLink,
 			expect:      "",
 			expectError: &TypeError{Actual: "int", Expected: []string{"*LinkObject", "string"}},
+		}, {
+			description: "Error with invalid Links.About.Meta",
+			given:       errorsWithInvalidLinkMeta,
+			expect:      "",
+			expectError: &TypeError{Actual: "string", Expected: []string{"struct", "map"}},
 		}, {
 			description: "Error empty",
 			given:       Error{},


### PR DESCRIPTION
Meta objects attached to links and errors were not previously checked for having the correct structure. This PR adds that validation and several tests.