### PR TITLE
Member Name Validation

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -79,6 +79,16 @@ func (e *PartialLinkageError) Error() string {
 	)
 }
 
+// MemberNameValidationError indicates that a document member name failed a validation step.
+type MemberNameValidationError struct {
+	MemberName string
+}
+
+// Error implements the error interface.
+func (e *MemberNameValidationError) Error() string {
+	return fmt.Sprintf("invalid member name: %s", e.MemberName)
+}
+
 // ErrorLink represents a JSON:API error links object as defined by https://jsonapi.org/format/1.0/#error-objects.
 type ErrorLink struct {
 	About any `json:"about,omitempty"`

--- a/jsonapi_test.go
+++ b/jsonapi_test.go
@@ -45,6 +45,7 @@ var (
 	articleLinkedInvalidRelated                  = ArticleLinkedInvalidRelated{ID: "1"}
 	articleLinkedInvalidMissingFields            = ArticleLinkedInvalidMissingFields{ID: "1"}
 	articleLinkedInvalidMissingFieldsEmptyValues = ArticleLinkedInvalidMissingFieldsEmptyValues{ID: "1"}
+	articleLinkedInvalidSelfMeta                 = ArticleLinkedInvalidSelfMeta{ID: "1"}
 	articleOmitTitleFull                         = ArticleOmitTitle{ID: "1"}
 	articleOmitTitlePartial                      = ArticleOmitTitle{ID: "1", Subtitle: "A"}
 	articleAIntID                                = ArticleIntID{ID: 1, Title: "A"}
@@ -119,7 +120,8 @@ var (
 	}
 	errorsComplexSliceMany    = []Error{errorsSimpleStruct, errorsComplexStruct}
 	errorsComplexSliceManyPtr = []*Error{&errorsSimpleStruct, &errorsComplexStruct}
-	errorsWithLinkObject      = Error{ //nolint: errname
+	errorsWithInvalidMeta     = Error{ID: "1", Meta: "foo"} //nolint: errname
+	errorsWithLinkObject      = Error{                      //nolint: errname
 		Links: &ErrorLink{
 			About: &LinkObject{
 				Href: "A",
@@ -130,7 +132,8 @@ var (
 			},
 		},
 	}
-	errorsWithInvalidLink = Error{Links: &ErrorLink{About: 1}} //nolint: errname
+	errorsWithInvalidLink     = Error{Links: &ErrorLink{About: 1}}                                   //nolint: errname
+	errorsWithInvalidLinkMeta = Error{Links: &ErrorLink{About: &LinkObject{Href: "A", Meta: "foo"}}} //nolint: errname
 
 	// error bodies
 	errorsSimpleStructBody     = `{"errors":[{"title":"T"}]}`
@@ -232,6 +235,14 @@ type ArticleLinkedInvalidMissingFieldsEmptyValues struct {
 func (a *ArticleLinkedInvalidMissingFieldsEmptyValues) Link() *Link {
 	var lo LinkObject
 	return &Link{Self: "", Related: &lo}
+}
+
+type ArticleLinkedInvalidSelfMeta struct {
+	ID string `jsonapi:"primary,articles"`
+}
+
+func (a *ArticleLinkedInvalidSelfMeta) Link() *Link {
+	return &Link{Self: &LinkObject{Href: "foo", Meta: "foo"}}
 }
 
 type ArticleOmitTitle struct {

--- a/marshal.go
+++ b/marshal.go
@@ -264,13 +264,14 @@ func makeDocumentErrors(v any, m *Marshaler) (*document, error) {
 		return nil, nil
 	}
 
-	// check for valid error links if present
+	// check for valid error links and meta fields if present
 	for _, eo := range errorObjects {
-		if eo.Links == nil {
-			continue
+		if eo.Links != nil {
+			if _, err := checkLinkValue(eo.Links.About); err != nil {
+				return nil, err
+			}
 		}
-
-		if _, err := checkLinkValue(eo.Links.About); err != nil {
+		if err := checkMeta(eo.Meta); err != nil {
 			return nil, err
 		}
 	}
@@ -483,17 +484,4 @@ func addOptionalDocumentFields(d *document, m *Marshaler) error {
 	d.Links = m.link
 
 	return nil
-}
-
-func checkMeta(m any) error {
-	if m == nil {
-		return nil
-	}
-
-	mt := derefType(reflect.TypeOf(m))
-	if mt.Kind() == reflect.Struct || mt.Kind() == reflect.Map {
-		return nil
-	}
-
-	return &TypeError{Actual: mt.String(), Expected: []string{"struct", "map"}}
 }

--- a/marshal.go
+++ b/marshal.go
@@ -18,12 +18,13 @@ func init() {
 // Marshaler is configured internally via MarshalOption's passed to Marshal.
 // It's used to configure the Marshaling by including optional fields like Meta or JSONAPI.
 type Marshaler struct {
-	meta           any
-	includeJSONAPI bool
-	jsonAPImeta    any
-	included       []any
-	link           *Link
-	clientMode     bool
+	meta                     any
+	includeJSONAPI           bool
+	jsonAPImeta              any
+	included                 []any
+	link                     *Link
+	clientMode               bool
+	memberNameValidationMode memberNameValidationMode
 
 	// fields support sparse fieldsets https://jsonapi.org/format/#fetching-sparse-fieldsets
 	fields map[string][]string
@@ -81,6 +82,27 @@ func MarshalLinks(l *Link) MarshalOption {
 func MarshalClientMode() MarshalOption {
 	return func(m *Marshaler) {
 		m.clientMode = true
+	}
+}
+
+// MarshalStrictNameValidation enables member name validation that is more strict than default.
+//
+// In addition to the basic naming rules from https://jsonapi.org/format/#document-member-names,
+// this option follows guidelines from https://jsonapi.org/recommendations/#naming.
+func MarshalStrictNameValidation() MarshalOption {
+	return func(m *Marshaler) {
+		m.memberNameValidationMode = strictValidation
+	}
+}
+
+// MarshalDisableNameValidation turns off member name validation, which may be useful for
+// compatibility or performance reasons.
+//
+// Note that this option allows you to use member names which do not conform to the JSON:API spec.
+// See https://jsonapi.org/format/#document-member-names.
+func MarshalDisableNameValidation() MarshalOption {
+	return func(m *Marshaler) {
+		m.memberNameValidationMode = disableValidation
 	}
 }
 

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -132,6 +132,11 @@ func TestMarshal(t *testing.T) {
 			expect:      "",
 			expectError: ErrMissingLinkFields,
 		}, {
+			description: "invalid Link.Self.Meta",
+			given:       &articleLinkedInvalidSelfMeta,
+			expect:      "",
+			expectError: &TypeError{Actual: "string", Expected: []string{"struct", "map"}},
+		}, {
 			description: "string",
 			given:       "a",
 			expect:      "",
@@ -231,6 +236,11 @@ func TestMarshal(t *testing.T) {
 			expect:      errorsComplexSliceManyBody,
 			expectError: nil,
 		}, {
+			description: "Error with invalid meta",
+			given:       errorsWithInvalidMeta,
+			expect:      "",
+			expectError: &TypeError{Actual: "string", Expected: []string{"struct", "map"}},
+		}, {
 			description: "Error with link object",
 			given:       errorsWithLinkObject,
 			expect:      errorsWithLinkObjectBody,
@@ -240,6 +250,11 @@ func TestMarshal(t *testing.T) {
 			given:       errorsWithInvalidLink,
 			expect:      "",
 			expectError: &TypeError{Actual: "int", Expected: []string{"*LinkObject", "string"}},
+		}, {
+			description: "Error with invalid Links.About.Meta",
+			given:       errorsWithInvalidLinkMeta,
+			expect:      "",
+			expectError: &TypeError{Actual: "string", Expected: []string{"struct", "map"}},
 		}, {
 			description: "Error empty",
 			given:       Error{},

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -637,10 +637,12 @@ func TestMarshalClientMode(t *testing.T) {
 	}
 }
 
+// TestMarshalMemberNameValidation collects tests which verify that invalid member names are caught
+// during marshaling, no matter where they're placed. This test does not exhaustively test every
+// possible invalid name.
 func TestMarshalMemberNameValidation(t *testing.T) {
 	t.Parallel()
 
-	// this test verifies that invalid member names are caught no matter where they're placed
 	tests := []struct {
 		description       string
 		given             any

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -636,3 +636,98 @@ func TestMarshalClientMode(t *testing.T) {
 		})
 	}
 }
+
+func TestMarshalMemberNameValidation(t *testing.T) {
+	t.Parallel()
+
+	// this test verifies that invalid member names are caught no matter where they're placed
+	tests := []struct {
+		description       string
+		given             any
+		expectError       error
+		additionalOptions []MarshalOption
+	}{
+		{
+			description: "Article with valid member names",
+			given:       &articleA,
+			expectError: nil,
+		}, {
+			description: "Author with invalid type name",
+			given:       &authorWithInvalidTypeName,
+			expectError: &MemberNameValidationError{"aut%hor"},
+		}, {
+			description: "Author with invalid attribute name",
+			given:       &authorWithInvalidAttributeName,
+			expectError: &MemberNameValidationError{"na%me"},
+		}, {
+			description: "Article with invalid resource meta member name",
+			given:       &articleWithInvalidResourceMetaMemberName,
+			expectError: &MemberNameValidationError{"foo%"},
+		}, {
+			description:       "Article with invalid top-level meta member name",
+			given:             &articleA,
+			expectError:       &MemberNameValidationError{"foo%"},
+			additionalOptions: []MarshalOption{MarshalMeta(map[string]any{"foo%": 2})},
+		}, {
+			description:       "Article with invalid jsonapi meta member name",
+			given:             &articleA,
+			expectError:       &MemberNameValidationError{"foo%"},
+			additionalOptions: []MarshalOption{MarshalJSONAPI(map[string]any{"foo%": 1})},
+		}, {
+			description: "Article with invalid link meta member name",
+			given:       &articleWithInvalidLinkMetaMemberName,
+			expectError: &MemberNameValidationError{"foo%"},
+		}, {
+			description: "Article with invalid relationship name",
+			given:       &articleWithInvalidRelationshipName,
+			expectError: &MemberNameValidationError{"aut%hor"},
+		}, {
+			description: "Article with invalid relationship type name",
+			given:       &articleWithInvalidRelationshipTypeName,
+			expectError: &MemberNameValidationError{"aut%hor"},
+		}, {
+			description: "Article with invalid relationship attribute name not included",
+			given:       &articleWithInvalidRelationshipAttributeName,
+			expectError: nil,
+		}, {
+			description:       "Article with invalid relationship attribute name included",
+			given:             &articleWithInvalidRelationshipAttributeName,
+			expectError:       &MemberNameValidationError{"na%me"},
+			additionalOptions: []MarshalOption{MarshalInclude(&authorWithInvalidAttributeName)},
+		}, {
+			description: "Articles with one invalid resource meta member name",
+			given: []*ArticleWithGenericMeta{
+				{ID: "1"}, {ID: "1", Meta: map[string]any{"foo%": 1}},
+			},
+			expectError: &MemberNameValidationError{"foo%"},
+		}, {
+			description: "Website with invalid nested relationship type name",
+			given:       &websiteWithInvalidNestedRelationshipTypeName,
+			expectError: &MemberNameValidationError{"aut%hor"},
+			additionalOptions: []MarshalOption{
+				MarshalInclude(
+					websiteWithInvalidNestedRelationshipTypeName.Articles[0],
+					websiteWithInvalidNestedRelationshipTypeName.Articles[1],
+					websiteWithInvalidNestedRelationshipTypeName.Articles[1].Author,
+				),
+			},
+		},
+	}
+
+	for i, tc := range tests {
+		tc := tc
+		t.Run(fmt.Sprintf("%02d", i), func(t *testing.T) {
+			t.Parallel()
+			t.Log(tc.description)
+
+			opts := tc.additionalOptions
+			_, err := Marshal(tc.given, opts...)
+			is.EqualError(t, tc.expectError, err)
+
+			opts = append(opts, MarshalDisableNameValidation())
+			_, err = Marshal(tc.given, opts...)
+			is.MustNoError(t, err)
+		})
+	}
+
+}

--- a/member_names.go
+++ b/member_names.go
@@ -12,7 +12,12 @@ var (
 )
 
 func init() {
+	// properties of the default name regex:
+	// - at least one character, no case requirements
+	// - dash, space, and underscore allowed anywhere except the ends of the string
+	// - no characters below unicode 0080 allowed
 	defaultNameRegex = regexp.MustCompile(`^([a-zA-Z\d]|[^\x{0000}-\x{0080}])(([a-zA-Z\d]|[^\x{0000}-\x{0080}])|[-_ ]([a-zA-Z\d]|[^\x{0000}-\x{0080}]))*$`)
+
 	// properties of the strict name regex:
 	// - at least one lower case letter
 	// - camel case, and must end with a lower case letter

--- a/member_names.go
+++ b/member_names.go
@@ -1,0 +1,51 @@
+package jsonapi
+
+import "regexp"
+
+var (
+	defaultNameRegex *regexp.Regexp
+	strictNameRegex  *regexp.Regexp
+)
+
+func init() {
+	defaultNameRegex = regexp.MustCompile(`^([a-zA-Z\d]|[^\x{0000}-\x{0080}])(([a-zA-Z\d]|[^\x{0000}-\x{0080}])|[-_ ]([a-zA-Z\d]|[^\x{0000}-\x{0080}]))*$`)
+	// properties of the strict name regex:
+	// - at least one lower case letter
+	// - camel case, and must end with a lower case letter
+	// - may have digits inside the word
+	strictNameRegex = regexp.MustCompile(`^([a-z]|[a-z]+((\d)|([A-Z\d][a-z\d]+))*([A-Z\d][a-z\d]*[a-z]))$`)
+}
+
+type memberNameValidationMode int
+
+const (
+	// defaultValidation verifies that member names are valid according to the spec in
+	// https://jsonapi.org/format/#document-member-names.
+	//
+	// Note that this validation mode allows for non-URL-safe member names.
+	defaultValidation memberNameValidationMode = iota
+
+	// disableValidation turns off member name validation for convenience and performance-saving
+	// reasons.
+	//
+	// Note that this validation mode allows for member names to not conform to the JSON:API spec.
+	disableValidation
+
+	// strictValidation verifies that member names are both valid according to the spec in
+	// https://jsonapi.org/format/#document-member-names, and follow recommendations from
+	// https://jsonapi.org/recommendations/#naming.
+	//
+	// Note that these names are always URL-safe.
+	strictValidation
+)
+
+func isValidMemberName(name string, mode memberNameValidationMode) bool {
+	switch mode {
+	case disableValidation:
+		return true
+	case strictValidation:
+		return strictNameRegex.MatchString(name)
+	default:
+		return defaultNameRegex.MatchString(name)
+	}
+}

--- a/member_names_test.go
+++ b/member_names_test.go
@@ -1,0 +1,62 @@
+package jsonapi
+
+import (
+	"testing"
+
+	"github.com/DataDog/jsonapi/internal/is"
+)
+
+func TestIsValidMemberName(t *testing.T) {
+	t.Parallel()
+
+	// associate member name strings with the strictest validation mode they should pass
+	testValidations := map[memberNameValidationMode][]string{
+		strictValidation: {
+			"a",
+			"lowercase1with2numerals",
+			"camelCase",
+			"camel12Case9WithNumera1s",
+		},
+		defaultValidation: {
+			"A",
+			"9camelCaseWithNumeralPrefix",
+			"camelCaseWithNumeralSuffix10",
+			"4camelCaseWithSurroundingNumerals5",
+			"camelC",
+			"PascalCase",
+			"dash-case",
+			"snake_case",
+			"space case",
+			"cRaZyCasE",
+			"12",
+			"ƒunky unicode",
+		},
+		disableValidation: {
+			"bad%character",
+		},
+	}
+
+	for mode, names := range testValidations {
+		mode := mode
+		for _, name := range names {
+			t.Run(name, func(t *testing.T) {
+				t.Parallel()
+
+				passesStrict := isValidMemberName(name, strictValidation)
+				passesDefault := isValidMemberName(name, defaultValidation)
+
+				switch mode {
+				case strictValidation:
+					is.Equal(t, true, passesStrict)
+					is.Equal(t, true, passesDefault)
+				case defaultValidation:
+					is.Equal(t, false, passesStrict)
+					is.Equal(t, true, passesDefault)
+				case disableValidation:
+					is.Equal(t, false, passesStrict)
+					is.Equal(t, false, passesDefault)
+				}
+			})
+		}
+	}
+}

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -45,6 +45,15 @@ func UnmarshalDisableNameValidation() UnmarshalOption {
 	}
 }
 
+// relationshipUnmarshaler creates a new marshaler from a parent one for the sake of unmarshaling
+// relationship documents, by copying over relevant fields.
+func (m *Unmarshaler) relationshipUnmarshaler() *Unmarshaler {
+	rm := new(Unmarshaler)
+
+	rm.memberNameValidationMode = m.memberNameValidationMode
+	return rm
+}
+
 // Unmarshal parses the json:api encoded data and stores the result in the value pointed to by v.
 // If v is nil or not a pointer, Unmarshal returns an error.
 func Unmarshal(data []byte, v any, opts ...UnmarshalOption) (err error) {
@@ -240,10 +249,8 @@ func (ro *resourceObject) unmarshalFields(v any, m *Unmarshaler) error {
 				// relDocument has no relationship data, so there's nothing to do
 				continue
 			}
-			// relationship unmarshaler needed for name validation
-			rm := new(Unmarshaler)
-			rm.memberNameValidationMode = m.memberNameValidationMode
 
+			rm := m.relationshipUnmarshaler()
 			rel := reflect.New(derefType(ft.Type)).Interface()
 			if err := relDocument.unmarshal(rel, rm); err != nil {
 				return err

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -8,8 +8,9 @@ import (
 // Unmarshaler is configured internally via UnmarshalOption's passed to Unmarshal.
 // It's used to configure the Unmarshaling by decoding optional fields like Meta.
 type Unmarshaler struct {
-	unmarshalMeta bool
-	meta          any
+	unmarshalMeta            bool
+	meta                     any
+	memberNameValidationMode memberNameValidationMode
 }
 
 // UnmarshalOption allows for configuration of Unmarshaling.
@@ -20,6 +21,27 @@ func UnmarshalMeta(meta any) UnmarshalOption {
 	return func(m *Unmarshaler) {
 		m.unmarshalMeta = true
 		m.meta = meta
+	}
+}
+
+// UnmarshalStrictNameValidation enables member name validation that is more strict than default.
+//
+// In addition to the basic naming rules from https://jsonapi.org/format/#document-member-names,
+// this option follows guidelines from https://jsonapi.org/recommendations/#naming.
+func UnmarshalStrictNameValidation() UnmarshalOption {
+	return func(m *Unmarshaler) {
+		m.memberNameValidationMode = strictValidation
+	}
+}
+
+// UnmarshalDisableNameValidation turns off member name validation, which may be useful for
+// compatibility or performance reasons.
+//
+// Note that this option allows you to use member names which do not conform to the JSON:API spec.
+// See https://jsonapi.org/format/#document-member-names.
+func UnmarshalDisableNameValidation() UnmarshalOption {
+	return func(m *Unmarshaler) {
+		m.memberNameValidationMode = disableValidation
 	}
 }
 

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -416,6 +416,9 @@ func TestUnmarshalMeta(t *testing.T) {
 	}
 }
 
+// TestUnmarshalMemberNameValidation collects tests which verify that invalid member names are
+// caught during unmarshaling, no matter where they're placed. This test does not exhaustively test
+// every possible invalid name.
 func TestUnmarshalMemberNameValidation(t *testing.T) {
 	t.Parallel()
 
@@ -424,7 +427,6 @@ func TestUnmarshalMemberNameValidation(t *testing.T) {
 	articleWithInvalidRelationshipAttributeNameNotIncludedBody := `{"data":{"id":"1","type":"articles","relationships":{"author":{"data":{"id":"1","type":"author"}}}}}`
 	articlesWithOneInvalidResourceMetaMemberName := `{"data":[{"id":"1","type":"articles"},{"id":"1","type":"articles","meta":{"foo%":1}}]}`
 
-	// this test verifies that invalid member names are caught no matter where they're placed
 	tests := []struct {
 		description string
 		given       string


### PR DESCRIPTION
Closes #19 

Featured in this PR:
- New marshal / unmarshal options for strict name validation or disabling name validation
- Default marshal / unmarshal behavior is to perform regular spec-conforming name validation

Tests:
- Extensive suite of tests for every interesting location in a JSON:API document in which member name validation matters
- Suite of tests for interesting member name validation test cases