### PR TITLE
Support encoding TextMarshaler and TextUnmarshaler

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,11 +100,37 @@ Both [jsonapi.Marshal](https://pkg.go.dev/github.com/DataDog/jsonapi#Marshal) an
 
 [Identification](https://jsonapi.org/format/1.0/#document-resource-object-identification) MUST be represented as a `string` regardless of the actual type in Go. To support non-string types for the primary field you can implement optional interfaces.
 
+You can implement the following on the parent types (that contain non-string fields):
+
+| Context | Interface |
+| --- | --- |
+| Marshal | [jsonapi.MarshalIdentifier](https://pkg.go.dev/github.com/DataDog/jsonapi#MarshalIdentifier) |
+| Unmarshal | [jsonapi.UnmarshalIdentifier](https://pkg.go.dev/github.com/DataDog/jsonapi#UnmarshalIdentifier) |
+
+You can implement the following on the field types themselves if they are not already implemented.
+
 | Context | Interface |
 | --- | --- |
 | Marshal | [fmt.Stringer](https://pkg.go.dev/fmt#Stringer) |
-| Marshal | [jsonapi.MarshalIdentifier](https://pkg.go.dev/github.com/DataDog/jsonapi#MarshalIdentifier) |
-| Unmarshal | [jsonapi.UnmarshalIdentifier](https://pkg.go.dev/github.com/DataDog/jsonapi#UnmarshalIdentifier) |
+| Marshal | [encoding.TextMarshaler](https://pkg.go.dev/encoding#TextMarshaler) |
+| Unmarshal | [encoding.TextUnmarshaler](https://pkg.go.dev/encoding#TextUnmarshaler) |
+
+### Order of Operations
+
+#### Marshaling
+
+1. Use MarshalIdentifier if it is implemented on the parent type
+2. Use the value directly if it is a string
+3. Use fmt.Stringer if it is implemented
+4. Use encoding.TextMarshaler if it is implemented
+5. Fail
+
+#### Unmarshaling
+
+1. Use UnmarshalIdentifier if it is implemented on the parent type
+2. Use encoding.TextUnmarshaler if it is implemented
+3. Use the value directly if it is a string
+4. Fail
 
 ## Links
 

--- a/jsonapi_test.go
+++ b/jsonapi_test.go
@@ -1,6 +1,7 @@
 package jsonapi
 
 import (
+	"encoding"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -54,6 +55,9 @@ var (
 	articleAIntIDID                              = ArticleIntIDID{ID: IntID(1), Title: "A"}
 	articleBIntIDID                              = ArticleIntIDID{ID: IntID(2), Title: "B"}
 	articlesIntIDIDABPtr                         = []*ArticleIntIDID{&articleAIntIDID, &articleBIntIDID}
+	articleAEncodingIntID                        = ArticleEncodingIntID{ID: EncodingIntID(1), Title: "A"}
+	articleBEncodingIntID                        = ArticleEncodingIntID{ID: EncodingIntID(2), Title: "B"}
+	articlesEncodingIntIDABPtr                   = []*ArticleEncodingIntID{&articleAEncodingIntID, &articleBEncodingIntID}
 	articleEmbedded                              = ArticleEmbedded{ID: "1", Title: "A", Metadata: Metadata{LastModified: time.Date(1989, 06, 15, 0, 0, 0, 0, time.UTC)}}
 	articleEmbeddedPointer                       = ArticleEmbeddedPointer{ID: "1", Title: "A", Metadata: &Metadata{LastModified: time.Date(1989, 06, 15, 0, 0, 0, 0, time.UTC)}}
 
@@ -310,6 +314,32 @@ func (a *ArticleIntIDID) UnmarshalID(id string) error {
 	}
 	a.ID = IntID(v)
 	return nil
+}
+
+var (
+	// ensure EncodingIntID implements encoding.[TextMarshaler|TextUnmarshaler]
+	_ encoding.TextMarshaler   = (*EncodingIntID)(nil)
+	_ encoding.TextUnmarshaler = (*EncodingIntID)(nil)
+)
+
+type EncodingIntID int
+
+func (i EncodingIntID) MarshalText() ([]byte, error) {
+	return []byte(fmt.Sprintf("%d", i)), nil
+}
+
+func (i *EncodingIntID) UnmarshalText(text []byte) error {
+	v, err := strconv.Atoi(string(text))
+	if err != nil {
+		return err
+	}
+	*i = EncodingIntID(v)
+	return nil
+}
+
+type ArticleEncodingIntID struct {
+	ID    EncodingIntID `jsonapi:"primary,articles"`
+	Title string        `jsonapi:"attribute" json:"title"`
 }
 
 type ArticleWithResourceObjectMeta struct {

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -167,6 +167,16 @@ func TestMarshal(t *testing.T) {
 			expect:      articlesABBody,
 			expectError: nil,
 		}, {
+			description: "*ArticleEncodingIntID (encoding.TextMarshaler)",
+			given:       &articleAEncodingIntID,
+			expect:      articleABody,
+			expectError: nil,
+		}, {
+			description: "[]*ArticleEncodinfIntID (encoding.TextMarshaler)",
+			given:       &articlesEncodingIntIDABPtr,
+			expect:      articlesABBody,
+			expectError: nil,
+		}, {
 			description: "non-string id",
 			given: &struct {
 				ID int `jsonapi:"primary,test"`

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -120,6 +120,26 @@ func TestUnmarshal(t *testing.T) {
 			expect:      []*ArticleIntIDID{&articleAIntIDID, &articleBIntIDID},
 			expectError: nil,
 		}, {
+			description: "*ArticleEncodingIntID",
+			given:       articleABody,
+			do: func(body []byte) (any, error) {
+				var a ArticleEncodingIntID
+				err := Unmarshal(body, &a)
+				return &a, err
+			},
+			expect:      &articleAEncodingIntID,
+			expectError: nil,
+		}, {
+			description: "[]*ArticleEncodingIntID",
+			given:       articlesABBody,
+			do: func(body []byte) (any, error) {
+				var a []*ArticleEncodingIntID
+				err := Unmarshal(body, &a)
+				return a, err
+			},
+			expect:      []*ArticleEncodingIntID{&articleAEncodingIntID, &articleBEncodingIntID},
+			expectError: nil,
+		}, {
 			description: "*ArticleWithMeta",
 			given:       articleAWithMetaBody,
 			do: func(body []byte) (any, error) {


### PR DESCRIPTION
Adds support for the encoding text interfaces.
- https://pkg.go.dev/encoding#TextMarshaler
- https://pkg.go.dev/encoding#TextUnmarshaler

This will allow common types like google/uuid.UUID to be used without requiring anything special to be implemented.