### PR TITLE
Support server-side id generation by allowing omitempty primary tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Like [encoding/json](https://pkg.go.dev/encoding/json) jsonapi is primarily cont
 
 | Tag | Usage | Description | Alias |
 | --- | --- | --- | --- |
-| primary | `jsonapi:"primary,{type}"` | Defines the [identification](https://jsonapi.org/format/1.0/#document-resource-object-identification) field. | N/A |
+| primary | `jsonapi:"primary,{type},{omitempty}"` | Defines the [identification](https://jsonapi.org/format/1.0/#document-resource-object-identification) field. Including omitempty allows for empty IDs (used for server-side id generation) | N/A |
 | attribute | `jsonapi:"attribute"` | Defines an [attribute](https://jsonapi.org/format/1.0/#document-resource-object-attributes). | attr |
 | relationship | `jsonapi:"relationship"` | Defines a [relationship](https://jsonapi.org/format/1.0/#document-resource-object-relationships). | rel |
 | meta | `jsonapi:"meta"` | Defines a [meta object](https://jsonapi.org/format/1.0/#document-meta). | N/A |

--- a/tags_test.go
+++ b/tags_test.go
@@ -103,6 +103,12 @@ func TestParseJSONAPITag(t *testing.T) {
 			}{},
 			expect: &tag{directive: primary, resourceType: "foo"},
 		}, {
+			description: "valid jsonapi, primary, omitempty",
+			given: struct {
+				Foo string `jsonapi:"primary,foo,omitempty"`
+			}{},
+			expect: &tag{directive: primary, resourceType: "foo", omitEmpty: true},
+		}, {
 			description: "no struct tags",
 			given:       struct{ Foo string }{},
 			expect:      nil,

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -218,6 +218,12 @@ func (ro *resourceObject) unmarshalFields(v any, m *Unmarshaler) error {
 				// type names count as member names
 				return &MemberNameValidationError{ro.Type}
 			}
+
+			// if omitempty is allowed, skip if this is an empty id
+			if jsonapiTag.omitEmpty && ro.ID == "" {
+				continue
+			}
+
 			// to unmarshal the id we follow these rules
 			//     1. Use UnmarshalIdentifier if it is implemented
 			//     2. Use encoding.TextUnmarshaler if it is implemented


### PR DESCRIPTION
This allows for empty IDs (by supporting omitempty on the primary tag) in cases where unmarshal would fail on empty (like google/uuid.UUID) so that server-side ID generation is supported.