### PR TITLE
feat: add json.Unmarshaler implementation to Error struct

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -132,6 +133,33 @@ func (e *Error) MarshalJSON() ([]byte, error) {
 		Status: status,
 		alias:  (*alias)(e),
 	})
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (e *Error) UnmarshalJSON(data []byte) error {
+	type alias Error
+
+	aux := &struct {
+		*alias
+		StatusStr string `json:"status"`
+	}{
+		alias: (*alias)(e),
+	}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	if aux.StatusStr != "" {
+		status, err := strconv.Atoi(aux.StatusStr)
+		if err != nil {
+			return err
+		}
+
+		e.Status = &status
+	}
+
+	return nil
 }
 
 // Error implements the error interface.

--- a/errors.go
+++ b/errors.go
@@ -141,7 +141,7 @@ func (e *Error) UnmarshalJSON(data []byte) error {
 
 	aux := &struct {
 		*alias
-		StatusStr string `json:"status"`
+		Status string `json:"status"`
 	}{
 		alias: (*alias)(e),
 	}
@@ -150,8 +150,8 @@ func (e *Error) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	if aux.StatusStr != "" {
-		status, err := strconv.Atoi(aux.StatusStr)
+	if aux.Status != "" {
+		status, err := strconv.Atoi(aux.Status)
 		if err != nil {
 			return err
 		}

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,22 @@
+package jsonapi
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/DataDog/jsonapi/internal/is"
+)
+
+func TestErrorMarshalUnmarshal(t *testing.T) {
+	t.Parallel()
+
+	expected := []byte(`{"id":"1","links":{"about":"A"},"status":"500","code":"C","title":"T","detail":"D","source":{"pointer":"PO","parameter":"PA"},"meta":{"K":"V"}}`)
+
+	var e Error
+	err := json.Unmarshal(expected, &e)
+	is.MustNoError(t, err)
+
+	actual, err := json.Marshal(&e)
+	is.MustNoError(t, err)
+	is.EqualJSON(t, string(expected), string(actual))
+}


### PR DESCRIPTION
An step to fix #28 

Just implement `json.Unmarshaler` interface to Error struct. This allows uses this type with native `json.Unmarshal()` correctly.