### PR TITLE
Create Marshal and Unmarshal benchmarks

### DIFF
--- a/jsonapi_test.go
+++ b/jsonapi_test.go
@@ -105,6 +105,7 @@ var (
 	articleALinkedBody                = `{"data":{"id":"1","type":"articles","attributes":{"title":"A"},"links":{"self":"https://example.com/articles/1","related":{"href":"https://example.com/articles/1/comments","meta":{"count":10}}}}}`
 	articleLinkedOnlySelfBody         = `{"data":{"id":"1","type":"articles","links":{"self":"https://example.com/articles/1"}}}`
 	articleWithResourceObjectMetaBody = `{"data":{"type":"articles","id":"1","attributes":{"title":"A"},"meta":{"count":10}}}`
+	articleAToplevelMetaBody          = `{"data":{"id":"1","type":"articles","attributes":{"title":"A"}},"meta":{"foo":"bar"}}`
 	articleAWithMetaBody              = `{"data":{"id":"1","type":"articles","attributes":{"title":"A"},"meta":{"views":10,"reads":4}}}`
 	articleEmbeddedBody               = `{"data":{"type":"articles","id":"1","attributes":{"title":"A","lastModified":"1989-06-15T00:00:00Z"}}}`
 

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -604,7 +604,7 @@ func BenchmarkUnmarshal(b *testing.B) {
 			target: Article{},
 			opts:   nil,
 		}, {
-			name:   "ArticleSimpleWithMeta",
+			name:   "ArticleSimpleWithToplevelMeta",
 			data:   articleAToplevelMetaBody,
 			target: Article{},
 			opts:   []UnmarshalOption{UnmarshalMeta(map[string]any{"foo": "bar"})},


### PR DESCRIPTION
Benchmarks are useful to catch performance regressions in the future. This PR also makes the name of some test articles with top-level meta objects more clear, as we use one in a benchmark.

Sample benchmark output on M1 Macbook:
```
❯ go test -bench .
goos: darwin
goarch: arm64
pkg: github.com/DataDog/jsonapi
BenchmarkMarshal/ArticleSimple-10                                 248750              4088 ns/op
BenchmarkMarshal/ArticleSimpleWithToplevelMeta-10                 227084              5221 ns/op
BenchmarkMarshal/ArticleComplex-10                                 47932             24306 ns/op
BenchmarkMarshal/ArticleComplexDisableNameValidation-10            63549             18420 ns/op
BenchmarkUnmarshal/ArticleSimple-10                               265260              4413 ns/op
BenchmarkUnmarshal/ArticleSimpleWithToplevelMeta-10               199671              5861 ns/op
BenchmarkUnmarshal/ArticleComplex-10                               34998             34165 ns/op
BenchmarkUnmarshal/ArticleComplexDisableNameValidation-10          41665             29277 ns/op
PASS
ok      github.com/DataDog/jsonapi      10.716s
```