### PR TITLE
Fix Unmarshaling of relationships with only links

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -28,11 +28,14 @@ var (
 	// ErrMissingLinkFields indicates that a LinkObject is not valid.
 	ErrMissingLinkFields = errors.New("at least one of Links.Self or Links.Related must be set to a nonempty string or *LinkObject")
 
-	// ErrMissingDataField indicates that a *jsonapi.document is missing data in an invalid way
-	ErrMissingDataField = errors.New("document is missing a required top-level or relationship-level data member")
-
 	// ErrEmptyDataObject indicates that a primary or relationship data member is incorrectly represented by an empty JSON object {}
 	ErrEmptyDataObject = errors.New("resource \"data\" members may not be represented by an empty object {}")
+
+	// ErrDocumentMissingRequiredMembers indicates that a document does not have at least one required top-level member
+	ErrDocumentMissingRequiredMembers = errors.New("document is missing required top-level members; must have one of: \"data\", \"meta\", \"errors\"")
+
+	// ErrRelationshipMissingRequiredMembers indicates that a relationship does not have at least one required member
+	ErrRelationshipMissingRequiredMembers = errors.New("relationship is missing required top-level members; must have one of: \"data\", \"meta\", \"links\"")
 )
 
 // TypeError indicates that an unexpected type was encountered.

--- a/jsonapi.go
+++ b/jsonapi.go
@@ -32,14 +32,14 @@ func (ro *resourceObject) UnmarshalJSON(data []byte) error {
 	}
 
 	ro.Relationships = make(map[string]*document, len(auxRaw.Rels))
-	for relName, documentRaw := range auxRaw.Rels {
+	for name, raw := range auxRaw.Rels {
 		// mark the created sub-documents as relationships so that the document Unmarshaler
 		// can handle their different member requirements
 		d := document{isRelationship: true}
-		if err := json.Unmarshal(documentRaw, &d); err != nil {
+		if err := json.Unmarshal(raw, &d); err != nil {
 			return err
 		}
-		ro.Relationships[relName] = &d
+		ro.Relationships[name] = &d
 	}
 	return nil
 }

--- a/jsonapi_test.go
+++ b/jsonapi_test.go
@@ -115,6 +115,7 @@ var (
 
 	// articles with relationships bodies
 	articleRelatedInvalidEmptyRelationshipBody  = `{"data":{"id":"1","type":"articles","attributes":{"title":"A"},"relationships":{"author":{}}}}`
+	articleRelatedInvalidEmptyDataBody          = `{"data":{"id":"1","type":"articles","attributes":{"title":"A"},"relationships":{"author":{"data":{}}}}}`
 	articleRelatedNoOmitEmptyBody               = `{"data":{"id":"1","type":"articles","attributes":{"title":"A"},"relationships":{"author":{"data":null},"comments":{"data":[]}}}}`
 	articleRelatedAuthorBody                    = `{"data":{"id":"1","type":"articles","attributes":{"title":"A"},"relationships":{"author":{"data":{"id":"1","type":"author"},"links":{"self":"http://example.com/articles/1/relationships/author","related":"http://example.com/articles/1/author"}}}}}`
 	articleRelatedAuthorTwiceBody               = `{"data":[{"id":"1","type":"articles","attributes":{"title":"A"},"relationships":{"author":{"data":{"id":"1","type":"author"}}}},{"id":"2","type":"articles","attributes":{"title":"B"},"relationships":{"author":{"data":{"id":"1","type":"author"}}}}]}`
@@ -126,6 +127,8 @@ var (
 	articleRelatedCompleteWithIncludeBody       = `{"data":{"id":"1","type":"articles","attributes":{"title":"A"},"relationships":{"author":{"data":{"id":"1","type":"author"}},"comments":{"data":[{"id":"1","type":"comments"},{"id":"2","type":"comments"}]}}},"included":[{"id":"1","type":"author","attributes":{"name":"A"}},{"id":"1","type":"comments","attributes":{"body":"A"}},{"id":"2","type":"comments","attributes":{"body":"B"}}]}`
 	articleRelatedCommentsNestedWithIncludeBody = `{"data":{"id":"1","type":"articles","attributes":{"title":"A"},"relationships":{"comments":{"data":[{"id":"1","type":"comments"}],"links":{"self":"http://example.com/articles/1/relationships/comments","related":"http://example.com/articles/1/comments"}}}},"included":[{"id":"1","type":"comments","attributes":{"body":"A"},"relationships":{"author":{"data":{"id":"1","type":"author"},"links":{"self":"http://example.com/comments/1/relationships/author","related":"http://example.com/comments/1/author"}}}},{"id":"1","type":"author","attributes":{"name":"A"}}]}`
 	articleWithIncludeOnlyBody                  = `{"data":{"id":"1","type":"articles","attributes":{"title":"A"}},"included":[{"id":"1","type":"author","attributes":{"name":"A"}}]}`
+	articleRelatedAuthorLinksOnlyBody           = `{"data":{"id":"1","type":"articles","attributes":{"title":"A"},"relationships":{"author":{"links":{"self":"http://example.com/articles/1/relationships/author","related":"http://example.com/articles/1/author"}}}}}`
+	articleRelatedAuthorMetaOnlyBody            = `{"data":{"id":"1","type":"articles","attributes":{"title":"A"},"relationships":{"author":{"meta":{"foo":"bar"}}}}}`
 
 	// articles with non-conforming member name bodies
 	authorWithInvalidTypeNameBody                           = `{"data":{"id":"1","type":"aut%hor"}}`

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -257,7 +257,7 @@ func TestUnmarshal(t *testing.T) {
 				return &a, err
 			},
 			expect:      new(Article),
-			expectError: ErrMissingDataField,
+			expectError: ErrDocumentMissingRequiredMembers,
 		}, {
 			description: "*Article (invalid type)",
 			given:       articleAInvalidTypeBody,
@@ -289,7 +289,7 @@ func TestUnmarshal(t *testing.T) {
 			expect:      new(Article),
 			expectError: &PartialLinkageError{[]string{"{Type: author, ID: 1}"}},
 		}, {
-			description: "*ArticleRelated empty relationships (invalid)",
+			description: "*ArticleRelated empty relationships object",
 			given:       articleRelatedInvalidEmptyRelationshipBody,
 			do: func(body []byte) (any, error) {
 				var a ArticleRelated
@@ -297,10 +297,10 @@ func TestUnmarshal(t *testing.T) {
 				return &a, err
 			},
 			expect:      &ArticleRelated{},
-			expectError: ErrMissingDataField,
+			expectError: ErrRelationshipMissingRequiredMembers,
 		}, {
-			// this test verifies that empty relationship bodies (null and []) unmarshal
-			description: "*ArticleRelated empty relationships",
+			// this test verifies that relationship data objects that are null or [] unmarshal
+			description: "*ArticleRelated empty relationships data (valid)",
 			given:       articleRelatedNoOmitEmptyBody,
 			do: func(body []byte) (any, error) {
 				var a ArticleRelated
@@ -309,6 +309,17 @@ func TestUnmarshal(t *testing.T) {
 			},
 			expect:      &ArticleRelated{ID: "1", Title: "A"},
 			expectError: nil,
+		}, {
+			// this test verifies that empty relationship data objects do not unmarshal
+			description: "*ArticleRelated empty relationships data (invalid)",
+			given:       articleRelatedInvalidEmptyDataBody,
+			do: func(body []byte) (any, error) {
+				var a ArticleRelated
+				err := Unmarshal(body, &a)
+				return &a, err
+			},
+			expect:      &ArticleRelated{},
+			expectError: ErrEmptyDataObject,
 		}, {
 			description: "*ArticleRelated.Author",
 			given:       articleRelatedAuthorBody,
@@ -322,6 +333,26 @@ func TestUnmarshal(t *testing.T) {
 				Title:  "A",
 				Author: &Author{ID: "1"},
 			},
+			expectError: nil,
+		}, {
+			description: "*ArticleRelated.Author (links only)",
+			given:       articleRelatedAuthorLinksOnlyBody,
+			do: func(body []byte) (any, error) {
+				var a ArticleRelated
+				err := Unmarshal(body, &a)
+				return &a, err
+			},
+			expect:      &ArticleRelated{ID: "1", Title: "A"},
+			expectError: nil,
+		}, {
+			description: "*ArticleRelated.Author (meta only)",
+			given:       articleRelatedAuthorMetaOnlyBody,
+			do: func(body []byte) (any, error) {
+				var a ArticleRelated
+				err := Unmarshal(body, &a)
+				return &a, err
+			},
+			expect:      &ArticleRelated{ID: "1", Title: "A"},
 			expectError: nil,
 		}, {
 			description: "[]*ArticleRelated.Author twice",
@@ -393,7 +424,7 @@ func TestUnmarshal(t *testing.T) {
 				return &a, err
 			},
 			expect:      &Article{},
-			expectError: ErrMissingDataField,
+			expectError: ErrDocumentMissingRequiredMembers,
 		},
 	}
 


### PR DESCRIPTION
Fixes #34

Relationships without a `"data"` member will not successfully unmarshal, so long as at least one other of the required members exists.

**NOTE**: Even if unmarshaling is successful, we don't necessarily do anything with the other fields (like link objects or metas in relationships). If deemed important, this can be tackled in a follow-up PR.

Benchmarks before the change:
```
❯ go test -bench '^BenchmarkUnmarshal'
goos: darwin
goarch: arm64
pkg: github.com/DataDog/jsonapi
BenchmarkUnmarshal/ArticleSimple-10                               277360              4323 ns/op
BenchmarkUnmarshal/ArticleSimpleWithToplevelMeta-10               213162              5480 ns/op
BenchmarkUnmarshal/ArticleComplex-10                               42676             28024 ns/op
BenchmarkUnmarshal/ArticleComplexDisableNameValidation-10          51916             22794 ns/op
BenchmarkUnmarshal/ArticlesComplex-10                               8203            141519 ns/op
BenchmarkUnmarshal/ArticlesComplexDisableNameValidation-10         10000            116609 ns/op
PASS
ok      github.com/DataDog/jsonapi      8.842s
```

Benchmarks after the change

```
❯ go test -bench '^BenchmarkUnmarshal'
goos: darwin
goarch: arm64
pkg: github.com/DataDog/jsonapi
BenchmarkUnmarshal/ArticleSimple-10                               206233              5052 ns/op
BenchmarkUnmarshal/ArticleSimpleWithToplevelMeta-10               193520              6204 ns/op
BenchmarkUnmarshal/ArticleComplex-10                               33628             35616 ns/op
BenchmarkUnmarshal/ArticleComplexDisableNameValidation-10          39631             30107 ns/op
BenchmarkUnmarshal/ArticlesComplex-10                               6302            181894 ns/op
BenchmarkUnmarshal/ArticlesComplexDisableNameValidation-10          7180            158011 ns/op
PASS
ok      github.com/DataDog/jsonapi      7.898s
```

For a large complex document, this change results in approximately 0.05 additional milliseconds spent Unmarshaling.