### PR TITLE
Add benchmark tests for complex slice

### DIFF
--- a/marshal_test.go
+++ b/marshal_test.go
@@ -619,6 +619,12 @@ func TestMarshalRelationships(t *testing.T) {
 			marshalOptions: []MarshalOption{MarshalInclude(&commentAWithAuthor, &authorA)},
 			expect:         "",
 			expectError:    &PartialLinkageError{[]string{"{Type: comments, ID: 1}", "{Type: author, ID: 1}"}},
+		}, {
+			description:    "multiple complex with included authors and comments",
+			given:          &articlesRelatedComplex,
+			marshalOptions: articlesRelatedComplexMarshalOptions,
+			expect:         articlesRelatedComplexBody,
+			expectError:    nil,
 		},
 	}
 
@@ -794,6 +800,17 @@ func BenchmarkMarshal(b *testing.B) {
 				MarshalInclude(&commentAWithAuthor, &authorA),
 				MarshalDisableNameValidation(),
 			},
+		}, {
+			name:  "ArticlesComplex",
+			given: articlesRelatedComplex,
+			opts:  articlesRelatedComplexMarshalOptions,
+		}, {
+			name:  "ArticlesComplexDisableNameValidation",
+			given: articlesRelatedComplex,
+			opts: append(
+				[]MarshalOption{MarshalDisableNameValidation()},
+				articlesRelatedComplexMarshalOptions...,
+			),
 		},
 	}
 

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -394,6 +394,16 @@ func TestUnmarshal(t *testing.T) {
 			},
 			expect:      &Article{},
 			expectError: ErrMissingDataField,
+		}, {
+			description: "[]*ArticleRelated complex relationships with include",
+			given:       articlesRelatedComplexBody,
+			do: func(body []byte) (any, error) {
+				var a []*ArticleRelated
+				err := Unmarshal(body, &a)
+				return &a, err
+			},
+			expect:      &articlesRelatedComplex,
+			expectError: nil,
 		},
 	}
 
@@ -721,6 +731,16 @@ func BenchmarkUnmarshal(b *testing.B) {
 			name:   "ArticleComplexDisableNameValidation",
 			data:   articleRelatedCommentsNestedWithIncludeBody,
 			target: ArticleRelated{},
+			opts:   []UnmarshalOption{UnmarshalDisableNameValidation()},
+		}, {
+			name:   "ArticlesComplex",
+			data:   articlesRelatedComplexBody,
+			target: []*ArticleRelated{},
+			opts:   nil,
+		}, {
+			name:   "ArticlesComplexDisableNameValidation",
+			data:   articlesRelatedComplexBody,
+			target: []*ArticleRelated{},
 			opts:   []UnmarshalOption{UnmarshalDisableNameValidation()},
 		},
 	}


### PR DESCRIPTION
```
❯ go test -bench .  # output below modified for clarity
goos: darwin
goarch: arm64
pkg: github.com/DataDog/jsonapi
BenchmarkMarshal/ArticleSimple-10                                 293390              4060 ns/op
BenchmarkMarshal/ArticleSimpleWithToplevelMeta-10                 226593              5138 ns/op
BenchmarkMarshal/ArticleComplex-10                                 49586             25175 ns/op
BenchmarkMarshal/ArticleComplexDisableNameValidation-10            63961             18497 ns/op

*NEW*
BenchmarkMarshal/ArticlesComplex-10                                 8398            135213 ns/op
*NEW*
BenchmarkMarshal/ArticlesComplexDisableNameValidation-10           10000            105118 ns/op

BenchmarkUnmarshal/ArticleSimple-10                               274716              4291 ns/op
BenchmarkUnmarshal/ArticleSimpleWithToplevelMeta-10               216309              5474 ns/op
BenchmarkUnmarshal/ArticleComplex-10                               42978             27738 ns/op
BenchmarkUnmarshal/ArticleComplexDisableNameValidation-10          52956             22555 ns/op

*NEW*
BenchmarkUnmarshal/ArticlesComplex-10                               8154            142857 ns/op
*NEW*
BenchmarkUnmarshal/ArticlesComplexDisableNameValidation-10          9799            117159 ns/op

PASS
ok      github.com/DataDog/jsonapi      16.367s
```