### PR TITLE
Begin jsonapi `v1.1` development branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 jsonapi
 -----
 
-Package jsonapi implements a marshaler/unmarshaler for [JSON:API v1.0](https://jsonapi.org/format/1.0).
+Package jsonapi implements a marshaler/unmarshaler for [JSON:API v1.1](https://jsonapi.org/format).
 
 # Version
 


### PR DESCRIPTION
This is a WIP development branch for json:api v1.1 and may not be merged as-is.

Development of missing JSON:API v1.1 features should occur in new branches with this one as a base, named `jsonapi-1.1-<feature-description>`