### PR TITLE
Allow all-lowercase as a strict name

### DIFF
--- a/member_names.go
+++ b/member_names.go
@@ -22,7 +22,7 @@ func init() {
 	// - at least one lower case letter
 	// - camel case, and must end with a lower case letter
 	// - may have digits inside the word
-	strictNameRegex = regexp.MustCompile(`^([a-z]|[a-z]+((\d)|([A-Z\d][a-z\d]+))*([A-Z\d][a-z\d]*[a-z]))$`)
+	strictNameRegex = regexp.MustCompile(`^[a-z]+(|(\d|([A-Z\d][a-z\d]+))*([A-Z\d][a-z\d]*[a-z]))$`)
 }
 
 // MemberNameValidationMode controls how document member names are checked for correctness.

--- a/member_names_test.go
+++ b/member_names_test.go
@@ -13,6 +13,7 @@ func TestIsValidMemberName(t *testing.T) {
 	testValidations := map[MemberNameValidationMode][]string{
 		StrictValidation: {
 			"a",
+			"lowercase",
 			"lowercase1with2numerals",
 			"camelCase",
 			"camel12Case9WithNumera1s",


### PR DESCRIPTION
For some reason I missed `"lowercase"` as a valid member name.

This fixes validation and simplifies the regex slightly