### PR TITLE
Force Unmarshal of errors to fail

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -36,6 +36,9 @@ var (
 
 	// ErrRelationshipMissingRequiredMembers indicates that a relationship does not have at least one required member
 	ErrRelationshipMissingRequiredMembers = errors.New("relationship is missing required top-level members; must have one of: \"data\", \"meta\", \"links\"")
+
+	// ErrErrorUnmarshalingNotImplemented indicates that an attempt was made to unmarshal an error document
+	ErrErrorUnmarshalingNotImplemented = errors.New("error unmarshaling is not implemented")
 )
 
 // TypeError indicates that an unexpected type was encountered.

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -93,6 +93,9 @@ func (d *document) unmarshal(v any, m *Unmarshaler) (err error) {
 		if err != nil {
 			return
 		}
+	} else if d.Errors != nil {
+		// TODO(#36): Support unmarshaling of errors
+		return ErrErrorUnmarshalingNotImplemented
 	}
 
 	err = d.unmarshalOptionalFields(m)

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -435,6 +435,17 @@ func TestUnmarshal(t *testing.T) {
 			},
 			expect:      &articlesRelatedComplex,
 			expectError: nil,
+		}, {
+			// TODO(#36): Add unmarshaling of errors as a supported use-case
+			description: "Errors don't unmarshal",
+			given:       errorsSimpleStructBody,
+			do: func(body []byte) (any, error) {
+				var a Article
+				err := Unmarshal(body, &a)
+				return &a, err
+			},
+			expect:      &Article{},
+			expectError: ErrErrorUnmarshalingNotImplemented,
 		},
 	}
 


### PR DESCRIPTION
Until Error unmarshaling is supported, attempts to unmarshal errors should fail to be compatible with previous behavior of the library.