### PR TITLE
Support anonymous/private primary fields

### DIFF
--- a/jsonapi_test.go
+++ b/jsonapi_test.go
@@ -41,6 +41,8 @@ var (
 			},
 		},
 	}
+	articleAPrivatePrimary                       = ArticlePrivatePrimary{id: "1", Title: "A"}
+	articleAAnonymousPrimary                     = ArticleAnonymousPrimary{"1", "A"}
 	articleALinked                               = ArticleLinked{ID: "1", Title: "A"}
 	articleLinkedOnlySelf                        = ArticleLinkedOnlySelf{ID: "1"}
 	articleLinkedInvalidSelf                     = ArticleLinkedInvalidSelf{ID: "1"}
@@ -230,6 +232,16 @@ type Article struct {
 
 	// Ignored is included to ensure un-tagged fields are ignored
 	Ignored string `json:"ignored"`
+}
+
+type ArticlePrivatePrimary struct {
+	id    string `jsonapi:"primary,articles"`
+	Title string `jsonapi:"attribute" json:"title"`
+}
+
+type ArticleAnonymousPrimary struct {
+	string `jsonapi:"primary,articles"`
+	Title  string `jsonapi:"attribute" json:"title"`
 }
 
 type ArticleMetrics struct {

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -97,6 +97,16 @@ func TestMarshal(t *testing.T) {
 			expect:      articlesABBody,
 			expectError: nil,
 		}, {
+			description: "ArticlePrivatePriamry",
+			given:       &articleAPrivatePrimary,
+			expect:      articlesABBody,
+			expectError: nil,
+		}, {
+			description: "ArticleAnonymousPrimary",
+			given:       &articleAAnonymousPrimary,
+			expect:      articlesABBody,
+			expectError: nil,
+		}, {
 			description: "*ArticleLinked",
 			given:       &articleALinked,
 			expect:      articleALinkedBody,

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -97,14 +97,14 @@ func TestMarshal(t *testing.T) {
 			expect:      articlesABBody,
 			expectError: nil,
 		}, {
-			description: "ArticlePrivatePriamry",
+			description: "ArticlePrivatePrimary",
 			given:       &articleAPrivatePrimary,
-			expect:      articlesABBody,
+			expect:      articleABody,
 			expectError: nil,
 		}, {
 			description: "ArticleAnonymousPrimary",
 			given:       &articleAAnonymousPrimary,
-			expect:      articlesABBody,
+			expect:      articleABody,
 			expectError: nil,
 		}, {
 			description: "*ArticleLinked",

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -4,6 +4,7 @@ import (
 	"encoding"
 	"encoding/json"
 	"reflect"
+	"unsafe"
 )
 
 // Unmarshaler is configured internally via UnmarshalOption's passed to Unmarshal.
@@ -230,6 +231,12 @@ func (ro *resourceObject) unmarshalFields(v any, m *Unmarshaler) error {
 			var fvi any
 			switch fv.CanAddr() {
 			case true:
+				if !fv.CanInterface() {
+					// while use of the unsafe package is generally discouraged, the following use-case
+					// is valid according to option 5 in the docs https://pkg.go.dev/unsafe#Pointer.
+					// This enables Unmarshaling of unexported/anonymous fields.
+					fv = reflect.NewAt(fv.Type(), unsafe.Pointer(fv.UnsafeAddr())).Elem()
+				}
 				fvi = fv.Addr().Interface()
 			default:
 				fvi = fv.Interface()

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -200,6 +200,26 @@ func TestUnmarshal(t *testing.T) {
 			expect:      []*ArticleEncodingIntID{&articleAEncodingIntID, &articleBEncodingIntID},
 			expectError: nil,
 		}, {
+			description: "*ArticlePrivatePrimary",
+			given:       articleABody,
+			do: func(body []byte) (any, error) {
+				var a ArticlePrivatePrimary
+				err := Unmarshal(body, &a)
+				return &a, err
+			},
+			expect:      &articleAPrivatePrimary,
+			expectError: nil,
+		}, {
+			description: "*ArticleAnonymousPrimary",
+			given:       articleABody,
+			do: func(body []byte) (any, error) {
+				var a ArticleAnonymousPrimary
+				err := Unmarshal(body, &a)
+				return &a, err
+			},
+			expect:      &articleAAnonymousPrimary,
+			expectError: nil,
+		}, {
 			description: "*ArticleWithMeta",
 			given:       articleAWithMetaBody,
 			do: func(body []byte) (any, error) {


### PR DESCRIPTION
- Support anonymous/un-exported primary fields in `Marshal` and `Unmarshal` 
- Updates variable names in  `marshal.go` for iterating over struct fields to be consistent with those in `unmarshal.go`