### PR TITLE
Skip unmarshalAttributes if there are no attributes

### DIFF
--- a/unmarshal.go
+++ b/unmarshal.go
@@ -293,6 +293,10 @@ func (ro *resourceObject) unmarshalFields(v any, m *Unmarshaler) error {
 }
 
 func (ro *resourceObject) unmarshalAttributes(v any) error {
+	if len(ro.Attributes) == 0 {
+		return nil
+	}
+
 	b, err := json.Marshal(ro.Attributes)
 	if err != nil {
 		return err

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -447,6 +447,28 @@ func TestUnmarshal(t *testing.T) {
 			expect:      &Article{},
 			expectError: ErrErrorUnmarshalingNotImplemented,
 		},
+		{
+			description: "ArticleLinkedOnlySelf",
+			given:       articleLinkedOnlySelfBody,
+			do: func(body []byte) (any, error) {
+				var a ArticleLinkedOnlySelf
+				err := Unmarshal(body, &a)
+				return &a, err
+			},
+			expect:      &articleLinkedOnlySelf,
+			expectError: nil,
+		},
+		{
+			description: "*ArticleLinkedOnlySelf",
+			given:       articleLinkedOnlySelfBody,
+			do: func(body []byte) (any, error) {
+				var a *ArticleLinkedOnlySelf
+				err := Unmarshal(body, &a)
+				return a, err
+			},
+			expect:      &articleLinkedOnlySelf,
+			expectError: nil,
+		},
 	}
 
 	for i, tc := range tests {


### PR DESCRIPTION
If a document contains no attributes then marshaling the nil/empty attribtute map to JSON produces a "null" string.

When attempting to decode this value to a pointer result, `json.Unmarshal` will nil out the pointer effectively making the entire json:api unmarshal result nil

This commit fixes the issue by skipping the attribute unmarshal if there are no attributes to unmarshal