### PR TITLE
Add support for 1.1 error objects

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -91,15 +91,17 @@ func (e *MemberNameValidationError) Error() string {
 	return fmt.Sprintf("invalid member name: %s", e.MemberName)
 }
 
-// ErrorLink represents a JSON:API error links object as defined by https://jsonapi.org/format/1.0/#error-objects.
+// ErrorLink represents a JSON:API error links object as defined by https://jsonapi.org/format/1.1/#error-objects.
 type ErrorLink struct {
 	About any `json:"about,omitempty"`
+	Type  any `json:"type,omitempty"`
 }
 
-// ErrorSource represents a JSON:API Error.Source as defined by https://jsonapi.org/format/1.0/#error-objects.
+// ErrorSource represents a JSON:API Error.Source as defined by https://jsonapi.org/format/1.1/#error-objects.
 type ErrorSource struct {
 	Pointer   string `json:"pointer,omitempty"`
 	Parameter string `json:"parameter,omitempty"`
+	Header    string `json:"header,omitempty"`
 }
 
 // Status provides a helper for setting an Error.Status value.
@@ -107,7 +109,7 @@ func Status(s int) *int {
 	return &s
 }
 
-// Error represents a JSON:API error object as defined by https://jsonapi.org/format/1.0/#error-objects.
+// Error represents a JSON:API error object as defined by https://jsonapi.org/format/1.1/#error-objects.
 type Error struct {
 	ID     string       `json:"id,omitempty"`
 	Links  *ErrorLink   `json:"links,omitempty"`

--- a/errors_test.go
+++ b/errors_test.go
@@ -10,7 +10,7 @@ import (
 func TestErrorMarshalUnmarshal(t *testing.T) {
 	t.Parallel()
 
-	expected := []byte(`{"id":"1","links":{"about":"A","type":TY"},"status":"500","code":"C","title":"T","detail":"D","source":{"pointer":"PO","parameter":"PA","header":"H"},"meta":{"K":"V"}}`)
+	expected := []byte(`{"id":"1","links":{"about":"A","type":"TY"},"status":"500","code":"C","title":"T","detail":"D","source":{"pointer":"PO","parameter":"PA","header":"H"},"meta":{"K":"V"}}`)
 
 	var e Error
 	err := json.Unmarshal(expected, &e)

--- a/errors_test.go
+++ b/errors_test.go
@@ -10,7 +10,7 @@ import (
 func TestErrorMarshalUnmarshal(t *testing.T) {
 	t.Parallel()
 
-	expected := []byte(`{"id":"1","links":{"about":"A"},"status":"500","code":"C","title":"T","detail":"D","source":{"pointer":"PO","parameter":"PA"},"meta":{"K":"V"}}`)
+	expected := []byte(`{"id":"1","links":{"about":"A","type":TY"},"status":"500","code":"C","title":"T","detail":"D","source":{"pointer":"PO","parameter":"PA","header":"H"},"meta":{"K":"V"}}`)
 
 	var e Error
 	err := json.Unmarshal(expected, &e)

--- a/jsonapi.go
+++ b/jsonapi.go
@@ -143,7 +143,7 @@ type document struct {
 	// JSONAPI is a JSON:API object as defined by https://jsonapi.org/format/1.0/#document-jsonapi-object.
 	JSONAPI *jsonAPI `json:"jsonapi,omitempty"`
 
-	// Errors is a list of JSON:API error objects as defined by https://jsonapi.org/format/1.0/#error-objects.
+	// Errors is a list of JSON:API error objects as defined by https://jsonapi.org/format/1.1/#error-objects.
 	Errors []*Error `json:"errors,omitempty"`
 
 	// Links is the top-level links object as defined by https://jsonapi.org/format/1.0/#document-top-level.

--- a/jsonapi_test.go
+++ b/jsonapi_test.go
@@ -198,12 +198,12 @@ var (
 	errorsSimpleSliceSinglePtr = []*Error{&errorsSimpleStruct}
 	errorsComplexStruct        = Error{ //nolint: errname
 		ID:     "1",
-		Links:  &ErrorLink{About: "A"},
+		Links:  &ErrorLink{About: "A", Type: "TY"},
 		Status: Status(http.StatusInternalServerError),
 		Code:   "C",
 		Title:  "T",
 		Detail: "D",
-		Source: &ErrorSource{Pointer: "PO", Parameter: "PA"},
+		Source: &ErrorSource{Pointer: "PO", Parameter: "PA", Header: "H"},
 		Meta:   map[string]string{"K": "V"},
 	}
 	errorsComplexSliceMany    = []Error{errorsSimpleStruct, errorsComplexStruct}
@@ -225,8 +225,8 @@ var (
 
 	// error bodies
 	errorsSimpleStructBody     = `{"errors":[{"title":"T"}]}`
-	errorsComplexStructBody    = `{"errors":[{"id":"1","links":{"about":"A"},"status":"500","code":"C","title":"T","detail":"D","source":{"pointer":"PO","parameter":"PA"},"meta":{"K":"V"}}]}`
-	errorsComplexSliceManyBody = `{"errors":[{"title":"T"},{"id":"1","links":{"about":"A"},"status":"500","code":"C","title":"T","detail":"D","source":{"pointer":"PO","parameter":"PA"},"meta":{"K":"V"}}]}`
+	errorsComplexStructBody    = `{"errors":[{"id":"1","links":{"about":"A","type":"TY"},"status":"500","code":"C","title":"T","detail":"D","source":{"pointer":"PO","parameter":"PA","header":"H"},"meta":{"K":"V"}}]}`
+	errorsComplexSliceManyBody = `{"errors":[{"title":"T"},{"id":"1","links":{"about":"A","type":"TY"},"status":"500","code":"C","title":"T","detail":"D","source":{"pointer":"PO","parameter":"PA","header":"H"},"meta":{"K":"V"}}]}`
 	errorsWithLinkObjectBody   = `{"errors":[{"links":{"about":{"href":"A","meta":{"key_i":420,"key_s":"B"}}}}]}`
 )
 


### PR DESCRIPTION
# Motivation
- We need error source for http headers in our error implementation. See https://jsonapi.org/format/1.1/#error-objects