### PR TITLE
Reject nonunique resources

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -37,6 +37,10 @@ var (
 	// ErrRelationshipMissingRequiredMembers indicates that a relationship does not have at least one required member
 	ErrRelationshipMissingRequiredMembers = errors.New("relationship is missing required top-level members; must have one of: \"data\", \"meta\", \"links\"")
 
+	// ErrNonuniqueResource indicates that multiple resource objects across the primary data and included sections share
+	// the same type & id, or multiple resource linkages with the same type & id exist in a relationship section
+	ErrNonuniqueResource = errors.New("\"type\" and \"id\" must be unique across resources")
+
 	// ErrErrorUnmarshalingNotImplemented indicates that an attempt was made to unmarshal an error document
 	ErrErrorUnmarshalingNotImplemented = errors.New("error unmarshaling is not implemented")
 )

--- a/jsonapi.go
+++ b/jsonapi.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
-	"slices"
 )
 
 // ResourceObject is a JSON:API resource object as defined by https://jsonapi.org/format/1.0/#document-resource-objects
@@ -330,7 +329,7 @@ func (d *document) verifyFullLinkage(aliasRelationships bool) error {
 func (d *document) verifyResourceUniqueness() bool {
 	topLevelSeen := make(map[string]struct{})
 
-	for _, ro := range slices.Concat(d.getResourceObjectSlice(), d.Included) {
+	for _, ro := range append(d.getResourceObjectSlice(), d.Included...) {
 		rid := ro.getIdentifier()
 		if _, ok := topLevelSeen[rid]; ro.ID != "" && ok {
 			return false

--- a/jsonapi.go
+++ b/jsonapi.go
@@ -327,23 +327,23 @@ func (d *document) verifyFullLinkage(aliasRelationships bool) error {
 // across primary data and included must be unique, and resource linkages must be unique in
 // any given relationship section.
 func (d *document) verifyResourceUniqueness() bool {
-	topLevelSeen := make(map[string]struct{})
+	topLevelSeen := make(map[string]bool)
 
 	for _, ro := range append(d.getResourceObjectSlice(), d.Included...) {
 		rid := ro.getIdentifier()
-		if _, ok := topLevelSeen[rid]; ro.ID != "" && ok {
+		if ro.ID != "" && topLevelSeen[rid] {
 			return false
 		}
-		topLevelSeen[rid] = struct{}{}
+		topLevelSeen[rid] = true
 
-		relSeen := make(map[string]struct{})
+		relSeen := make(map[string]bool)
 		for _, rel := range ro.Relationships {
 			for _, relRo := range rel.getResourceObjectSlice() {
 				relRid := relRo.getIdentifier()
-				if _, ok := relSeen[relRid]; relRo.ID != "" && ok {
+				if relRo.ID != "" && relSeen[relRid] {
 					return false
 				}
-				relSeen[relRid] = struct{}{}
+				relSeen[relRid] = true
 			}
 		}
 	}

--- a/jsonapi_test.go
+++ b/jsonapi_test.go
@@ -31,6 +31,7 @@ var (
 	articleANoID    = Article{Title: "A"}
 	articleB        = Article{ID: "2", Title: "B"}
 	articlesAB      = []Article{articleA, articleB}
+	articlesAA      = []Article{articleA, articleA}
 	articlesABPtr   = []*Article{&articleA, &articleB}
 	articleComplete = ArticleComplete{
 		ID:       "1",
@@ -77,15 +78,16 @@ var (
 	articleWithoutResourceObjectMeta = ArticleWithResourceObjectMeta{ID: "1", Title: "A"}
 
 	// articles with relationships
-	articleRelated                 = ArticleRelated{ID: "1", Title: "A"}
-	articleRelatedNoOmitEmpty      = ArticleRelatedNoOmitEmpty{ID: "1", Title: "A"}
-	articleRelatedAuthor           = ArticleRelated{ID: "1", Title: "A", Author: &authorA}
-	articleRelatedAuthorWithMeta   = ArticleRelated{ID: "1", Title: "A", Author: &authorAWithMeta}
-	articleRelatedComments         = ArticleRelated{ID: "1", Title: "A", Comments: []*Comment{&commentA}}
-	articleRelatedCommentsArchived = ArticleRelated{ID: "1", Title: "A", Comments: []*Comment{&commentArchived}}
-	articleRelatedCommentsNested   = ArticleRelated{ID: "1", Title: "A", Comments: []*Comment{&commentAWithAuthor}}
-	articleRelatedComplete         = ArticleRelated{ID: "1", Title: "A", Author: &authorAWithMeta, Comments: commentsAB}
-	articlesRelatedComplex         = []*ArticleRelated{
+	articleRelated                  = ArticleRelated{ID: "1", Title: "A"}
+	articleRelatedNoOmitEmpty       = ArticleRelatedNoOmitEmpty{ID: "1", Title: "A"}
+	articleRelatedAuthor            = ArticleRelated{ID: "1", Title: "A", Author: &authorA}
+	articleRelatedAuthorWithMeta    = ArticleRelated{ID: "1", Title: "A", Author: &authorAWithMeta}
+	articleRelatedComments          = ArticleRelated{ID: "1", Title: "A", Comments: []*Comment{&commentA}}
+	articleRelatedNonuniqueComments = ArticleRelated{ID: "1", Title: "A", Comments: []*Comment{&commentA, &commentA}}
+	articleRelatedCommentsArchived  = ArticleRelated{ID: "1", Title: "A", Comments: []*Comment{&commentArchived}}
+	articleRelatedCommentsNested    = ArticleRelated{ID: "1", Title: "A", Comments: []*Comment{&commentAWithAuthor}}
+	articleRelatedComplete          = ArticleRelated{ID: "1", Title: "A", Author: &authorAWithMeta, Comments: commentsAB}
+	articlesRelatedComplex          = []*ArticleRelated{
 		{
 			ID:     "1",
 			Title:  "Bazel 101",
@@ -153,6 +155,7 @@ var (
 	articleOmitTitleFullBody              = `{"data":{"type":"articles","id":"1"}}`
 	articleOmitTitlePartialBody           = `{"data":{"type":"articles","id":"1","attributes":{"subtitle":"A"}}}`
 	articlesABBody                        = `{"data":[{"type":"articles","id":"1","attributes":{"title":"A"}},{"type":"articles","id":"2","attributes":{"title":"B"}}]}`
+	articlesABNonuniqueData               = `{"data":[{"type":"articles","id":"1","attributes":{"title":"A"}},{"type":"articles","id":"1","attributes":{"title":"B"}}]}`
 	articleCompleteBody                   = `{"data":{"id":"1","type":"articles","attributes":{"info":{"publishDate":"1989-06-15T00:00:00Z","tags":["a","b"],"isPublic":true,"metrics":{"views":10,"reads":4}},"title":"A","subtitle":"AA"}}}`
 	articleALinkedBody                    = `{"data":{"id":"1","type":"articles","attributes":{"title":"A"},"links":{"self":"https://example.com/articles/1","related":{"href":"https://example.com/articles/1/comments","meta":{"count":10}}}}}`
 	articleLinkedOnlySelfBody             = `{"data":{"id":"1","type":"articles","links":{"self":"https://example.com/articles/1"}}}`
@@ -178,6 +181,7 @@ var (
 	articleRelatedCommentsWithIncludeBody       = `{"data":{"id":"1","type":"articles","attributes":{"title":"A"},"relationships":{"comments":{"data":[{"id":"1","type":"comments"}],"links":{"self":"http://example.com/articles/1/relationships/comments","related":"http://example.com/articles/1/comments"}}}},"included":[{"id":"1","type":"comments","attributes":{"body":"A"},"relationships":{"author":{"data":{"id":"1","type":"author"},"links":{"self":"http://example.com/comments/1/relationships/author","related":"http://example.com/comments/1/author"}}}}]}`
 	articleRelatedCompleteBody                  = `{"data":{"id":"1","type":"articles","attributes":{"title":"A"},"relationships":{"author":{"data":{"id":"1","type":"author"},"meta":{"count":10},"links":{"self":"http://example.com/articles/1/relationships/author","related":"http://example.com/articles/1/author"}},"comments":{"data":[{"id":"1","type":"comments"},{"id":"2","type":"comments"}],"links":{"self":"http://example.com/articles/1/relationships/comments","related":"http://example.com/articles/1/comments"}}}}}`
 	articleRelatedCompleteWithIncludeBody       = `{"data":{"id":"1","type":"articles","attributes":{"title":"A"},"relationships":{"author":{"data":{"id":"1","type":"author"}},"comments":{"data":[{"id":"1","type":"comments"},{"id":"2","type":"comments"}]}}},"included":[{"id":"1","type":"author","attributes":{"name":"A"}},{"id":"1","type":"comments","attributes":{"body":"A"}},{"id":"2","type":"comments","attributes":{"body":"B"}}]}`
+	articleRelatedNonuniqueLinkage              = `{"data":{"id":"1","type":"articles","attributes":{"title":"A"},"relationships":{"author":{"data":{"id":"1","type":"author"}},"comments":{"data":[{"id":"1","type":"comments"},{"id":"1","type":"comments"}]}}}}`
 	articleRelatedCommentsNestedWithIncludeBody = `{"data":{"id":"1","type":"articles","attributes":{"title":"A"},"relationships":{"comments":{"data":[{"id":"1","type":"comments"}],"links":{"self":"http://example.com/articles/1/relationships/comments","related":"http://example.com/articles/1/comments"}}}},"included":[{"id":"1","type":"comments","attributes":{"body":"A"},"relationships":{"author":{"data":{"id":"1","type":"author"},"links":{"self":"http://example.com/comments/1/relationships/author","related":"http://example.com/comments/1/author"}}}},{"id":"1","type":"author","attributes":{"name":"A"}}]}`
 	articleWithIncludeOnlyBody                  = `{"data":{"id":"1","type":"articles","attributes":{"title":"A"}},"included":[{"id":"1","type":"author","attributes":{"name":"A"}}]}`
 	articleRelatedAuthorLinksOnlyBody           = `{"data":{"id":"1","type":"articles","attributes":{"title":"A"},"relationships":{"author":{"links":{"self":"http://example.com/articles/1/relationships/author","related":"http://example.com/articles/1/author"}}}}}`

--- a/marshal.go
+++ b/marshal.go
@@ -205,6 +205,9 @@ func makeDocument(v any, m *Marshaler, isRelationship bool) (*document, error) {
 		d.Included = append(d.Included, ro)
 	}
 
+	if ok := d.verifyResourceUniqueness(); !ok {
+		return nil, ErrNonuniqueResource
+	}
 	// if we got any included data, verify full-linkage of this compound document.
 	if err := d.verifyFullLinkage(false); err != nil {
 		return nil, err

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -82,6 +82,11 @@ func TestMarshal(t *testing.T) {
 			expect:      articlesABBody,
 			expectError: nil,
 		}, {
+			description: "[]Article (nonunique data)",
+			given:       articlesAA,
+			expect:      "",
+			expectError: ErrNonuniqueResource,
+		}, {
 			description: "[]*Article",
 			given:       articlesABPtr,
 			expect:      articlesABBody,
@@ -585,6 +590,12 @@ func TestMarshalRelationships(t *testing.T) {
 			expect:         articleRelatedCommentsBody,
 			expectError:    nil,
 		}, {
+			description:    "with related nonunique comments",
+			given:          &articleRelatedNonuniqueComments,
+			marshalOptions: nil,
+			expect:         "",
+			expectError:    ErrNonuniqueResource,
+		}, {
 			description:    "with related author and comments",
 			given:          &articleRelatedComplete,
 			marshalOptions: nil,
@@ -752,7 +763,7 @@ func TestMarshalMemberNameValidation(t *testing.T) {
 		}, {
 			description: "Articles with one invalid resource meta member name",
 			given: []*ArticleWithGenericMeta{
-				{ID: "1"}, {ID: "1", Meta: map[string]any{"foo%": 1}},
+				{ID: "1"}, {ID: "2", Meta: map[string]any{"foo%": 1}},
 			},
 			expectError: &MemberNameValidationError{"foo%"},
 		}, {

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -88,6 +88,9 @@ func Unmarshal(data []byte, v any, opts ...UnmarshalOption) (err error) {
 }
 
 func (d *document) unmarshal(v any, m *Unmarshaler) (err error) {
+	if ok := d.verifyResourceUniqueness(); !ok {
+		return ErrNonuniqueResource
+	}
 	// verify full-linkage in-case this is a compound document
 	if err = d.verifyFullLinkage(true); err != nil {
 		return
@@ -142,7 +145,7 @@ func unmarshalResourceObjects(ros []*resourceObject, v any, m *Unmarshaler) erro
 	outType := derefType(reflect.TypeOf(v))
 	outValue := derefValue(reflect.ValueOf(v))
 
-	// first, it must be a struct since we'll be parsing the jsonapi struct tags
+	// first, it must be a slice since we'll be parsing multiple resource objects
 	if outType.Kind() != reflect.Slice {
 		return &TypeError{Actual: outType.String(), Expected: []string{"slice"}}
 	}

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -70,6 +70,16 @@ func TestUnmarshal(t *testing.T) {
 			expect:      []Article{articleA, articleB},
 			expectError: nil,
 		}, {
+			description: "[]Article (nonunique data)",
+			given:       articlesABNonuniqueData,
+			do: func(body []byte) (any, error) {
+				var a []Article
+				err := Unmarshal(body, &a)
+				return a, err
+			},
+			expect:      ([]Article)(nil),
+			expectError: ErrNonuniqueResource,
+		}, {
 			description: "[]Article (empty)",
 			given:       emptyManyBody,
 			do: func(body []byte) (any, error) {
@@ -416,6 +426,16 @@ func TestUnmarshal(t *testing.T) {
 			expect:      &articleRelatedCommentsNested,
 			expectError: nil,
 		}, {
+			description: "ArticleRelated (nonunique linkage)",
+			given:       articleRelatedNonuniqueLinkage,
+			do: func(body []byte) (any, error) {
+				var a ArticleRelated
+				err := Unmarshal(body, &a)
+				return a, err
+			},
+			expect:      ArticleRelated{},
+			expectError: ErrNonuniqueResource,
+		}, {
 			description: "links member only",
 			given:       `{"links":null}`,
 			do: func(body []byte) (any, error) {
@@ -712,7 +732,7 @@ func TestUnmarshalMemberNameValidation(t *testing.T) {
 	articleWithInvalidToplevelMetaMemberNameBody := `{"data":{"id":"1","type":"articles","attributes":{"title":"A"}},"meta":{"foo%":2}}`
 	articleWithInvalidJSONAPIMetaMemberNameBody := `{"data":{"id":"1","type":"articles","attributes":{"title":"A"}},"jsonapi":{"version":"1.0","meta":{"foo%":1}}}`
 	articleWithInvalidRelationshipAttributeNameNotIncludedBody := `{"data":{"id":"1","type":"articles","relationships":{"author":{"data":{"id":"1","type":"author"}}}}}`
-	articlesWithOneInvalidResourceMetaMemberName := `{"data":[{"id":"1","type":"articles"},{"id":"1","type":"articles","meta":{"foo%":1}}]}`
+	articlesWithOneInvalidResourceMetaMemberName := `{"data":[{"id":"1","type":"articles"},{"id":"2","type":"articles","meta":{"foo%":1}}]}`
 
 	tests := []struct {
 		description string


### PR DESCRIPTION
Issue: https://github.com/DataDog/jsonapi/issues/33

## About me
This PR adds logic to check that, per jsonapi's spec, `a single canonical resource object is returned with each response`. It checks resource objects across the primary data and included sections to find duplicates (duplicate being resources objects with the same type & id). It also checks every relationship section for duplicates.

The following documents were previously accepted but now rejected:

Duplicate resource objects in primary data
```
{
  "data": [
    {
      "id": "1",
      "type": "articles",
      "attributes": {
        "title": "A"
      }
    },
    {
      "id": "1",
      "type": "articles",
      "attributes": {
        "title": "B"
      }
    }
  ]
}
```

Duplicate resource objects in included section
```
{
  "data": {
      "id": "1",
      "type": "articles",
      "attributes": {
        "title": "A"
      },
      "relationships": {
        "comments": {
          "data": { "type": "comments", "id": "1" }
        }
      }
    },
  "included": [{
    "type": "comments",
    "id": "1",
    "attributes": {
      "body": "I like XML better"
    }
  }, {
    "type": "comments",
    "id": "1",
    "attributes": {
      "body": "I like YAML better"
    }
  }]
}
```

Duplicate resource objects across primary data and included
```
{
  "data": [{
      "id": "1",
      "type": "employees",
      "attributes": {
        "name": "John Doe"
      },
      "relationships": {
        "managers": {
          "data": { "type": "employees", "id": "2" }
        }
      }
    }, {
      "id": "2",
      "type": "employees",
      "attributes": {
        "name": "Mary Jane"
      },
      "relationships": {
        "managers": {
          "data": { "type": "employees", "id": "3" }
        }
      }
    }],
  "included": [{
    "type": "employees",
    "id": "2",
    "attributes": {
      "name": "Mary Jane"
    }
  }]
}
```

Duplicate resource linkages
```
{
  "data": {
      "id": "1",
      "type": "articles",
      "attributes": {
        "title": "A"
      },
      "relationships": {
        "comments": {
          "data": [{ "type": "comments", "id": "1" }, { "type": "comments", "id": "1"}]
        }
      }
   }
}
```

## Testing
Added tests that cause error to be thrown

## Questions
- [ ] The jsonapi spec specifically calls out resource objects to be unique, but it doesn't mention resource linkages (the last example in the About me section). Is checking for duplicate resource linkages in every relationship section overkill?