### PR TITLE
Add "prev" field in Link attribute

### DIFF
--- a/jsonapi.go
+++ b/jsonapi.go
@@ -75,7 +75,8 @@ type LinkObject struct {
 }
 
 // Link is the top-level links object as defined by https://jsonapi.org/format/1.0/#document-top-level.
-// First|Last|Next|Previous are provided to support pagination as defined by https://jsonapi.org/format/1.0/#fetching-pagination.
+// First|Last|Next|Prev are provided to support pagination as defined by https://jsonapi.org/format/1.0/#fetching-pagination.
+// Previous is kept for backwards compatibility
 type Link struct {
 	Self    any `json:"self,omitempty"`
 	Related any `json:"related,omitempty"`
@@ -84,6 +85,7 @@ type Link struct {
 	Last     string `json:"last,omitempty"`
 	Next     string `json:"next,omitempty"`
 	Previous string `json:"previous,omitempty"`
+	Prev     string `json:"prev,omitempty"`
 }
 
 func checkLinkValue(linkValue any) (bool, *TypeError) {

--- a/jsonapi.go
+++ b/jsonapi.go
@@ -76,14 +76,14 @@ type LinkObject struct {
 
 // Link is the top-level links object as defined by https://jsonapi.org/format/1.0/#document-top-level.
 // First|Last|Next|Prev are provided to support pagination as defined by https://jsonapi.org/format/1.0/#fetching-pagination.
-// Previous is kept for backwards compatibility
 type Link struct {
 	Self    any `json:"self,omitempty"`
 	Related any `json:"related,omitempty"`
 
-	First    string `json:"first,omitempty"`
-	Last     string `json:"last,omitempty"`
-	Next     string `json:"next,omitempty"`
+	First string `json:"first,omitempty"`
+	Last  string `json:"last,omitempty"`
+	Next  string `json:"next,omitempty"`
+	// Previous is deprecated and kept for backwards compatibility. Instead, use the Prev field.
 	Previous string `json:"previous,omitempty"`
 	Prev     string `json:"prev,omitempty"`
 }


### PR DESCRIPTION
In [JSON API](https://jsonapi.org/format/1.0/#fetching-pagination) specification, there are 4 fields that are mandatory : 
* `first`: the first page of data
* `last`: the last page of data
* `prev`: the previous page of data
* `next`: the next page of data

There is currently a `previous` field but no `prev` field. This PR add `prev` field and keeps `previous` field for backwards compatibility