### PR TITLE
Check uniqueness of resources is now opt-in

### DIFF
--- a/marshal_test.go
+++ b/marshal_test.go
@@ -20,6 +20,7 @@ func TestMarshal(t *testing.T) {
 		given       any
 		expect      string
 		expectError error
+		opts        []MarshalOption
 	}{
 		{
 			description: "nil",
@@ -86,6 +87,7 @@ func TestMarshal(t *testing.T) {
 			given:       articlesAA,
 			expect:      "",
 			expectError: ErrNonuniqueResource,
+			opts:        []MarshalOption{MarshallCheckUniqueness()},
 		}, {
 			description: "[]*Article",
 			given:       articlesABPtr,
@@ -592,7 +594,7 @@ func TestMarshalRelationships(t *testing.T) {
 		}, {
 			description:    "with related nonunique comments",
 			given:          &articleRelatedNonuniqueComments,
-			marshalOptions: nil,
+			marshalOptions: []MarshalOption{MarshallCheckUniqueness()},
 			expect:         "",
 			expectError:    ErrNonuniqueResource,
 		}, {

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -287,11 +287,11 @@ func TestMarshal(t *testing.T) {
 
 	for i, tc := range tests {
 		tc := tc
-		t.Run(fmt.Sprintf("%02d", i), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%02d - %s", i, tc.description), func(t *testing.T) {
 			t.Parallel()
 			t.Log(tc.description)
 
-			actual, err := Marshal(tc.given)
+			actual, err := Marshal(tc.given, tc.opts...)
 			if tc.expectError != nil {
 				is.EqualError(t, tc.expectError, err)
 				is.Nil(t, actual)
@@ -643,7 +643,7 @@ func TestMarshalRelationships(t *testing.T) {
 
 	for i, tc := range tests {
 		tc := tc
-		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%d - %s", i, tc.description), func(t *testing.T) {
 			t.Parallel()
 			t.Log(tc.description)
 

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -11,6 +11,7 @@ import (
 type Unmarshaler struct {
 	unmarshalMeta            bool
 	unmarshalLinks           bool
+	checkUniqueness          bool
 	meta                     any
 	links                    *Link
 	memberNameValidationMode MemberNameValidationMode
@@ -32,6 +33,13 @@ func UnmarshalLinks(link *Link) UnmarshalOption {
 	return func(m *Unmarshaler) {
 		m.unmarshalLinks = true
 		m.links = link
+	}
+}
+
+// UnmarshalCheckUniqueness enables checking for unique resources during unmarshaling.
+func UnmarshalCheckUniqueness() UnmarshalOption {
+	return func(m *Unmarshaler) {
+		m.checkUniqueness = true
 	}
 }
 
@@ -88,8 +96,10 @@ func Unmarshal(data []byte, v any, opts ...UnmarshalOption) (err error) {
 }
 
 func (d *document) unmarshal(v any, m *Unmarshaler) (err error) {
-	if ok := d.verifyResourceUniqueness(); !ok {
-		return ErrNonuniqueResource
+	if m.checkUniqueness {
+		if ok := d.verifyResourceUniqueness(); !ok {
+			return ErrNonuniqueResource
+		}
 	}
 	// verify full-linkage in-case this is a compound document
 	if err = d.verifyFullLinkage(true); err != nil {

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -74,7 +74,7 @@ func TestUnmarshal(t *testing.T) {
 			given:       articlesABNonuniqueData,
 			do: func(body []byte) (any, error) {
 				var a []Article
-				err := Unmarshal(body, &a)
+				err := Unmarshal(body, &a, UnmarshalCheckUniqueness())
 				return a, err
 			},
 			expect:      ([]Article)(nil),
@@ -430,7 +430,7 @@ func TestUnmarshal(t *testing.T) {
 			given:       articleRelatedNonuniqueLinkage,
 			do: func(body []byte) (any, error) {
 				var a ArticleRelated
-				err := Unmarshal(body, &a)
+				err := Unmarshal(body, &a, UnmarshalCheckUniqueness())
 				return a, err
 			},
 			expect:      ArticleRelated{},


### PR DESCRIPTION
Following the addition of uniqueness check in https://github.com/DataDog/jsonapi/pull/59, we would like to have it optional so there is no breaking change in the lib. 
It could be in the 1.0 roadmap (breaking) to set it by default. 

@20joshuaz, please note that in 0.12.0+, you will need to use the option MarshallCheckUniqueness / UnmarshalCheckUniqueness