### PR TITLE
Fix Uniqueness check by there is relationship to the same object but under 2 relationships keys

### DIFF
--- a/jsonapi.go
+++ b/jsonapi.go
@@ -333,15 +333,17 @@ func (d *document) verifyResourceUniqueness() bool {
 		rid := ro.getIdentifier()
 		if ro.ID != "" && topLevelSeen[rid] {
 			return false
+			//panic(fmt.Sprintf("Normal: %+v, %s", topLevelSeen, rid))
 		}
 		topLevelSeen[rid] = true
 
-		relSeen := make(map[string]bool)
 		for _, rel := range ro.Relationships {
+			relSeen := make(map[string]bool)
 			for _, relRo := range rel.getResourceObjectSlice() {
 				relRid := relRo.getIdentifier()
 				if relRo.ID != "" && relSeen[relRid] {
 					return false
+					//panic(fmt.Sprintf("Rel: %+v, %s", relSeen, relRid))
 				}
 				relSeen[relRid] = true
 			}

--- a/jsonapi.go
+++ b/jsonapi.go
@@ -333,7 +333,6 @@ func (d *document) verifyResourceUniqueness() bool {
 		rid := ro.getIdentifier()
 		if ro.ID != "" && topLevelSeen[rid] {
 			return false
-			//panic(fmt.Sprintf("Normal: %+v, %s", topLevelSeen, rid))
 		}
 		topLevelSeen[rid] = true
 
@@ -343,7 +342,6 @@ func (d *document) verifyResourceUniqueness() bool {
 				relRid := relRo.getIdentifier()
 				if relRo.ID != "" && relSeen[relRid] {
 					return false
-					//panic(fmt.Sprintf("Rel: %+v, %s", relSeen, relRid))
 				}
 				relSeen[relRid] = true
 			}

--- a/jsonapi_test.go
+++ b/jsonapi_test.go
@@ -182,6 +182,7 @@ var (
 	articleRelatedCompleteBody                  = `{"data":{"id":"1","type":"articles","attributes":{"title":"A"},"relationships":{"author":{"data":{"id":"1","type":"author"},"meta":{"count":10},"links":{"self":"http://example.com/articles/1/relationships/author","related":"http://example.com/articles/1/author"}},"comments":{"data":[{"id":"1","type":"comments"},{"id":"2","type":"comments"}],"links":{"self":"http://example.com/articles/1/relationships/comments","related":"http://example.com/articles/1/comments"}}}}}`
 	articleRelatedCompleteWithIncludeBody       = `{"data":{"id":"1","type":"articles","attributes":{"title":"A"},"relationships":{"author":{"data":{"id":"1","type":"author"}},"comments":{"data":[{"id":"1","type":"comments"},{"id":"2","type":"comments"}]}}},"included":[{"id":"1","type":"author","attributes":{"name":"A"}},{"id":"1","type":"comments","attributes":{"body":"A"}},{"id":"2","type":"comments","attributes":{"body":"B"}}]}`
 	articleRelatedNonuniqueLinkage              = `{"data":{"id":"1","type":"articles","attributes":{"title":"A"},"relationships":{"author":{"data":{"id":"1","type":"author"}},"comments":{"data":[{"id":"1","type":"comments"},{"id":"1","type":"comments"}]}}}}`
+	articleRelatedDifferentRefToSameObject      = `{"data":{"id":"1","type":"articles","attributes":{"title":"A"},"relationships":{"author":{"data":{"id":"1","type":"author"}},"contact":{"data":{"id":"1","type":"author"}},"comments":{"data":[{"id":"1","type":"comments"}]}}}}`
 	articleRelatedCommentsNestedWithIncludeBody = `{"data":{"id":"1","type":"articles","attributes":{"title":"A"},"relationships":{"comments":{"data":[{"id":"1","type":"comments"}],"links":{"self":"http://example.com/articles/1/relationships/comments","related":"http://example.com/articles/1/comments"}}}},"included":[{"id":"1","type":"comments","attributes":{"body":"A"},"relationships":{"author":{"data":{"id":"1","type":"author"},"links":{"self":"http://example.com/comments/1/relationships/author","related":"http://example.com/comments/1/author"}}}},{"id":"1","type":"author","attributes":{"name":"A"}}]}`
 	articleWithIncludeOnlyBody                  = `{"data":{"id":"1","type":"articles","attributes":{"title":"A"}},"included":[{"id":"1","type":"author","attributes":{"name":"A"}}]}`
 	articleRelatedAuthorLinksOnlyBody           = `{"data":{"id":"1","type":"articles","attributes":{"title":"A"},"relationships":{"author":{"links":{"self":"http://example.com/articles/1/relationships/author","related":"http://example.com/articles/1/author"}}}}}`
@@ -438,6 +439,14 @@ type Author struct {
 type ArticleRelated struct {
 	ID       string     `jsonapi:"primary,articles"`
 	Title    string     `jsonapi:"attribute" json:"title"`
+	Author   *Author    `jsonapi:"relationship" json:"author,omitempty"`
+	Comments []*Comment `jsonapi:"relationship" json:"comments,omitempty"`
+}
+
+type ArticleRelatedWithContact struct {
+	ID       string     `jsonapi:"primary,articles"`
+	Title    string     `jsonapi:"attribute" json:"title"`
+	Contact  *Author    `jsonapi:"relationship" json:"contact,omitempty"`
 	Author   *Author    `jsonapi:"relationship" json:"author,omitempty"`
 	Comments []*Comment `jsonapi:"relationship" json:"comments,omitempty"`
 }

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -1,6 +1,7 @@
 package jsonapi
 
 import (
+	_ "embed"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -435,7 +436,25 @@ func TestUnmarshal(t *testing.T) {
 			},
 			expect:      ArticleRelated{},
 			expectError: ErrNonuniqueResource,
-		}, {
+		},
+		{
+			description: "ArticleRelatedWithContact (nonunique linkage)",
+			given:       articleRelatedDifferentRefToSameObject,
+			do: func(body []byte) (any, error) {
+				var a ArticleRelatedWithContact
+				err := Unmarshal(body, &a)
+				return &a, err
+			},
+			expect: &ArticleRelatedWithContact{
+				ID:       "1",
+				Title:    "A",
+				Author:   &Author{ID: "1"},
+				Comments: []*Comment{{ID: "1"}},
+				Contact:  &Author{ID: "1"},
+			},
+			expectError: nil,
+		},
+		{
 			description: "links member only",
 			given:       `{"links":null}`,
 			do: func(body []byte) (any, error) {

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -1,7 +1,6 @@
 package jsonapi
 
 import (
-	_ "embed"
 	"encoding/json"
 	"fmt"
 	"reflect"


### PR DESCRIPTION
Spec : https://jsonapi.org/format/1.1/#document-resource-object-relationships
Allow some json+api document that have relationships to a same object but under differents relation key : 
```
{
    "data": {
        "id": "1",
        "type": "articles",
        "attributes": {
            "title": "A"
        },
        "relationships": {
            "author": {
                "data": {
                    "id": "1",
                    "type": "author"
                }
            },
            "contact": {
                "data": {
                    "id": "1",
                    "type": "author"
                }
            },
            "comments": {
                "data": [
                    {
                        "id": "1",
                        "type": "comments"
                    }
                ]
            }
        }
    }
}
```