### PR TITLE
Consider nil `*Link`s as per se valid

### DIFF
--- a/jsonapi.go
+++ b/jsonapi.go
@@ -109,6 +109,10 @@ func checkLinkValue(linkValue any) (bool, *TypeError) {
 }
 
 func (l *Link) check() error {
+	if l == nil {
+		return nil
+	}
+
 	selfIsEmpty, err := checkLinkValue(l.Self)
 	if err != nil {
 		return err


### PR DESCRIPTION
Nothing in the JSON:API spec requires links (usually e.g. it’s either links or data), and nothing requires that if one relation has a related resource link, all must.

This allows `LinkRelation` to return nil for related resources which may not have exposed linkage routes in an API.